### PR TITLE
Ignore aliases (fixes #536)

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -9,7 +9,7 @@
 NVM_SCRIPT_SOURCE="$_"
 
 nvm_has() {
-  type "$1" > /dev/null 2>&1
+  which "$1" > /dev/null 2>&1
 }
 
 nvm_download() {


### PR DESCRIPTION
A better solution would be to see if the installed `sha1` supports the `-q` option and use a fallback command if it doesn't. But this way, if you create a `sha1` alias on mac, nvm will at least install node.