### PR TITLE
[install script] Refactors NVM_DIR

### DIFF
--- a/test/install_script/nvm_install_dir
+++ b/test/install_script/nvm_install_dir
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+cleanup () {
+  unset -f die cleanup
+  unset install_dir
+}
+die () { echo $@ ; cleanup ; exit 1; }
+
+NVM_ENV=testing . ../../install.sh
+HOME="__home__"
+
+
+# NVM_DIR is set
+NVM_DIR="some_dir" 
+install_dir=$(nvm_install_dir)
+[ "_$install_dir" = "_$NVM_DIR" ] || die "nvm_install_dir should use \$NVM_DIR if it exists. Current output: $install_dir"
+
+unset NVM_DIR
+
+# NVM_DIR is not set
+install_dir=$(nvm_install_dir)
+[ "_$install_dir" = "_$HOME/.nvm" ] || die "nvm_install_dir should default to \$HOME/.nvm. Current output: $install_dir"
+
+cleanup
+


### PR DESCRIPTION
After the PR:
* Uses a function to define the install dir (aka `NVM_DIR`)
* Does not replace an empty yet defined `NVM_DIR` variable, but uses a default value instead
* `NVM_DIR` is used at a single point in the install script
