### PR TITLE
303 nvm in fish

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 
-# Get this script after dereferincing all symlinks
-# !! Doesn't check for circular symlinks !!
-SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
-  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-  SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-done
-DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-
 set -e
 
 nvm_has() {

--- a/nvm
+++ b/nvm
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Get this script after dereferincing all symlinks
+# !! Doesn't check for circular symlinks !!
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+source "$DIR/nvm.sh"
+'nvm' $@

--- a/nvm.fish
+++ b/nvm.fish
@@ -1,0 +1,24 @@
+function nvm --description "Node version manager" -a nvm_command nvm_command_arg1
+  set nvm_dir ~/.nvm
+  set nvm_ $nvm_dir/nvm
+
+  # This sets some environment vars that we need to set too
+  if test "$nvm_command" = "use"
+    eval $nvm_ use --print-paths $nvm_command_arg1 | sed -re "s|^(\w+=)|set -x \1|g" -e "s|[=:]| |g" | grep "set -x"  | .
+  else
+    # Make sure we can use node
+    if test ! (which node)
+      # Have we installed node at all ?
+      if eval $nvm_ ls | grep "N/A" > /dev/null
+        echo "No node installation found, installing stable"
+        eval $nvm_ install stable
+      end
+      # Make sure we have a default picked
+      if eval $nvm_ ls default | grep "N/A"
+        eval $nvm_ alias default stable
+      end
+      nvm use default
+    end
+    eval $nvm_ $argv
+  end
+end

--- a/nvm.sh
+++ b/nvm.sh
@@ -531,22 +531,22 @@ nvm() {
       echo "Node Version Manager"
       echo
       echo "Usage:"
-      echo "    nvm help                    Show this message"
-      echo "    nvm --version               Print out the latest released version of nvm"
-      echo "    nvm install [-s] <version>  Download and install a <version>, [-s] from source. Uses .nvmrc if available"
-      echo "    nvm uninstall <version>     Uninstall a version"
-      echo "    nvm use <version>           Modify PATH to use <version>. Uses .nvmrc if available"
-      echo "    nvm run <version> [<args>]  Run <version> with <args> as arguments. Uses .nvmrc if available for <version>"
-      echo "    nvm current                 Display currently activated version"
-      echo "    nvm ls                      List installed versions"
-      echo "    nvm ls <version>            List versions matching a given description"
-      echo "    nvm ls-remote               List remote versions available for install"
-      echo "    nvm deactivate              Undo effects of NVM on current shell"
-      echo "    nvm alias [<pattern>]       Show all aliases beginning with <pattern>"
-      echo "    nvm alias <name> <version>  Set an alias named <name> pointing to <version>"
-      echo "    nvm unalias <name>          Deletes the alias named <name>"
-      echo "    nvm copy-packages <version> Install global NPM packages contained in <version> to current version"
-      echo "    nvm unload                  Unload NVM from shell"
+      echo "    nvm help                             Show this message"
+      echo "    nvm --version                        Print out the latest released version of nvm"
+      echo "    nvm install [-s] <version>           Download and install a <version>, [-s] from source. Uses .nvmrc if available"
+      echo "    nvm uninstall <version>              Uninstall a version"
+      echo "    nvm [--print-paths] use <version>    Modify PATH (and optionally print it) to use <version>. Uses .nvmrc if available"
+      echo "    nvm run <version> [<args>]           Run <version> with <args> as arguments. Uses .nvmrc if available for <version>"
+      echo "    nvm current                          Display currently activated version"
+      echo "    nvm ls                               List installed versions"
+      echo "    nvm ls <version>                     List versions matching a given description"
+      echo "    nvm ls-remote                        List remote versions available for install"
+      echo "    nvm deactivate                       Undo effects of NVM on current shell"
+      echo "    nvm alias [<pattern>]                Show all aliases beginning with <pattern>"
+      echo "    nvm alias <name> <version>           Set an alias named <name> pointing to <version>"
+      echo "    nvm unalias <name>                   Deletes the alias named <name>"
+      echo "    nvm copy-packages <version>          Install global NPM packages contained in <version> to current version"
+      echo "    nvm unload                           Unload NVM from shell"
       echo
       echo "Example:"
       echo "    nvm install v0.10.24        Install a specific version number"
@@ -794,20 +794,35 @@ nvm() {
       fi
     ;;
     "use" )
+      shift # start treating the args given to "use"
+
       if [ $# -eq 0 ]; then
-        nvm help
-        return 127
-      fi
-      if [ $# -eq 1 ]; then
         nvm_rc_version
         if [ -n "$NVM_RC_VERSION" ]; then
           VERSION=`nvm_version $NVM_RC_VERSION`
         fi
-      elif [ "_$2" != '_system' ]; then
-        VERSION="$(nvm_version "$2")"
       else
-        VERSION="$2"
+        # Handle options
+        while [[ $# > 0 ]]; do
+                key="$1"
+                shift
+          case $key in 
+                  --print-paths)
+              PRINT_PATHS=true
+            ;;
+
+                  *)
+              if [ "_$key" != '_system' ]; then
+                      VERSION="$(nvm_version "$key")"
+                    else
+                      VERSION="$key"
+                    fi
+              break
+            ;;
+          esac
+        done
       fi
+
       if [ -z "$VERSION" ]; then
         nvm help
         return 127
@@ -822,7 +837,7 @@ nvm() {
           return 127
         fi
       elif [ "_$VERSION" = "_∞" ]; then
-        echo "The alias \"$2\" leads to an infinite loop. Aborting." >&2
+        echo "The alias \"$1\" leads to an infinite loop. Aborting." >&2
         return 8
       fi
 
@@ -857,6 +872,12 @@ nvm() {
       export NVM_BIN="$NVM_VERSION_DIR/bin"
       if [ "$NVM_SYMLINK_CURRENT" = true ]; then
         rm -f "$NVM_DIR/current" && ln -s "$NVM_VERSION_DIR" "$NVM_DIR/current"
+      fi
+      if [ $PRINT_PATHS ]; then
+        echo PATH=$PATH
+        echo NODE_PATH=$NODE_PATH
+        echo NVM_PATH=$NVM_PATH
+        echo NVM_BIN=$NVM_BIN
       fi
       echo "Now using node $VERSION"
     ;;

--- a/nvm.sh
+++ b/nvm.sh
@@ -803,10 +803,10 @@ nvm() {
         fi
       else
         # Handle options
-        while [[ $# > 0 ]]; do
+        while [ $# > 0 ]; do
                 key="$1"
                 shift
-          case $key in 
+          case $key in
                   --print-paths)
               PRINT_PATHS=true
             ;;

--- a/nvm.sh
+++ b/nvm.sh
@@ -837,7 +837,7 @@ nvm() {
           return 127
         fi
       elif [ "_$VERSION" = "_∞" ]; then
-        echo "The alias \"$1\" leads to an infinite loop. Aborting." >&2
+        echo "The alias \"$key\" leads to an infinite loop. Aborting." >&2
         return 8
       fi
 


### PR DESCRIPTION
Hi,

Related to #303 , I use fish myself and love that I can run `npm install -g <...>` with nvm --> fish nvm was needed.

This is simply a wrapper around nvm for fish. I have commented my commits as much as possible to help understand my thought process. I hope others with fish can test this (tests in vagrant worked for me).  
A wrapper allows nvm to change below without (hopefully) affecting functionality in fish.

I'm open to critical feedback or improvement suggestions.

Cheers