### PR TITLE
Introduce copy METHOD for installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
 
-# Get this script after dereferincing all symlinks
-# !! Doesn't check for circular symlinks !!
-SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
-  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-  SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-done
-DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-
 set -e
+
+# Adapted from stackoverflow: https://stackoverflow.com/a/246128
+# Get's the path of the current script calling the function
+# !! Doesn't check for circular symlinks !!
+# e.g /tmp/path/to/script.sh
+function nvm_script_path(){
+  SOURCE=$0
+  while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  done
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  FILENAME=`basename $SOURCE`
+  echo $DIR/$FILENAME
+}
+
+# Get the directory of the current script
+function nvm_script_dir(){
+  echo "$( dirname $(nvm_script_path))"
+}
 
 nvm_has() {
   type "$1" > /dev/null 2>&1
@@ -122,6 +133,7 @@ nvm_do_install() {
   # Copies install.sh dir to installation dir
   elif [ "~$METHOD" = "~copy" ]; then
     local COPY=true
+    DIR=`nvm_script_dir`
     if [ $DIR = $NVM_DIR ]; then
       echo "=> install.sh is already in $NVM_DIR"
       COPY=false

--- a/install.sh
+++ b/install.sh
@@ -132,7 +132,8 @@ nvm_do_install() {
     install_nvm_as_script
   # Copies install.sh dir to installation dir
   elif [ "~$METHOD" = "~copy" ]; then
-    local COPY=true
+    local COPY
+    COPY=true
     DIR=`nvm_script_dir`
     if [ $DIR = $NVM_DIR ]; then
       echo "=> install.sh is already in $NVM_DIR"

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Get this script after dereferincing all symlinks
+# !! Doesn't check for circular symlinks !!
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
 set -e
 
 nvm_has() {
@@ -109,6 +119,19 @@ nvm_do_install() {
       exit 1
     fi
     install_nvm_as_script
+  # Copies install.sh dir to installation dir
+  elif [ "~$METHOD" = "~copy" ]; then
+    local COPY=true
+    if [ $DIR = $NVM_DIR ]; then
+      echo "=> install.sh is already in $NVM_DIR"
+      COPY=false
+    elif [ -d $NVM_DIR ]; then
+      echo "=> $NVM_DIR already exists and its contents will be replaced"
+    fi
+    mkdir -p $NVM_DIR
+    if $COPY; then
+      cp -R $DIR/* $NVM_DIR
+    fi
   fi
 
   echo

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ set -e
 # Get's the path of the current script calling the function
 # !! Doesn't check for circular symlinks !!
 # e.g /tmp/path/to/script.sh
-function nvm_script_path(){
+nvm_script_path(){
   SOURCE=$0
   while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
     DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
@@ -19,7 +19,7 @@ function nvm_script_path(){
 }
 
 # Get the directory of the current script
-function nvm_script_dir(){
+nvm_script_dir(){
   echo "$( dirname $(nvm_script_path))"
 }
 


### PR DESCRIPTION
This method copies the folder containing install.sh (normally also containing the repo) to  - unless of course the install.sh being executed is in  (where nvm was installed)

This is useful for vagrant to test local changes instead of pulling them from git and thus testing what's on the server and not local changes

As [requested](https://github.com/creationix/nvm/pull/578#discussion_r20406227), here is a seperate PR for the copy method for installation.
