### PR TITLE
Fix which command in zsh (#604).

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -272,7 +272,7 @@ nvm_alias() {
 
 nvm_ls_current() {
   local NVM_LS_CURRENT_NODE_PATH
-  NVM_LS_CURRENT_NODE_PATH="$(which node 2> /dev/null)"
+  NVM_LS_CURRENT_NODE_PATH="$(command which node 2> /dev/null)"
   if [ $? -ne 0 ]; then
     echo 'none'
   elif nvm_tree_contains_path "$NVM_DIR" "$NVM_LS_CURRENT_NODE_PATH"; then
@@ -984,7 +984,7 @@ nvm() {
       if [ "_$VERSION" = '_system' ]; then
         if nvm_has_system_node >/dev/null 2>&1; then
           local NVM_BIN
-          NVM_BIN="$(nvm use system >/dev/null 2>&1 && which node)"
+          NVM_BIN="$(nvm use system >/dev/null 2>&1 && command which node)"
           if [ -n "$NVM_BIN" ]; then
             echo "$NVM_BIN"
             return

--- a/test/fast/Unit tests/nvm_ls_current
+++ b/test/fast/Unit tests/nvm_ls_current
@@ -12,8 +12,8 @@ TEST_PWD=$(pwd)
 TEST_DIR="$TEST_PWD/nvm_ls_current_tmp"
 rm -rf "$TEST_DIR"
 mkdir "$TEST_DIR"
-ln -s "$(which which)" "$TEST_DIR/which"
-ln -s "$(which dirname)" "$TEST_DIR/dirname"
+ln -s "$(command which which)" "$TEST_DIR/which"
+ln -s "$(command which dirname)" "$TEST_DIR/dirname"
 
 [ "$(PATH="$TEST_DIR" nvm_ls_current)" = "none" ] || die 'when node not installed, nvm_ls_current did not return "none"'
 [ "@$(PATH="$TEST_DIR" nvm_ls_current 2> /dev/stdout 1> /dev/null)@" = "@@" ] || die 'when node not installed, nvm_ls_current returned error output'


### PR DESCRIPTION
use `command which` to ignore zsh's buildin command `which`.

zsh's `which` will not return the path to node if someone create a alias like `alias node="node --harmony"`.

