### PR TITLE
`io.js` support

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1309,23 +1309,32 @@ nvm() {
 
       local NVM_LS_REMOTE_EXIT_CODE
       NVM_LS_REMOTE_EXIT_CODE=0
+      local NVM_LS_REMOTE_OUTPUT
+      NVM_LS_REMOTE_OUTPUT=''
       if [ "_$NVM_FLAVOR" != "_$(nvm_iojs_prefix)" ]; then
-        local NVM_LS_REMOTE_OUTPUT
         NVM_LS_REMOTE_OUTPUT=$(nvm_ls_remote "$PATTERN")
         NVM_LS_REMOTE_EXIT_CODE=$?
-        nvm_print_versions "$NVM_LS_REMOTE_OUTPUT"
       fi
 
       local NVM_LS_REMOTE_IOJS_EXIT_CODE
       NVM_LS_REMOTE_IOJS_EXIT_CODE=0
+      local NVM_LS_REMOTE_IOJS_OUTPUT
+      NVM_LS_REMOTE_IOJS_OUTPUT=''
       if [ "_$NVM_FLAVOR" != "_$(nvm_node_prefix)" ]; then
-        local NVM_LS_REMOTE_IOJS_OUTPUT
         NVM_LS_REMOTE_IOJS_OUTPUT=$(nvm_ls_remote_iojs "$PATTERN")
         NVM_LS_REMOTE_IOJS_EXIT_CODE=$?
-        nvm_print_versions "$NVM_LS_REMOTE_IOJS_OUTPUT"
       fi
 
-      return $NVM_LS_REMOTE_EXIT_CODE && $NVM_LS_REMOTE_IOJS_EXIT_CODE
+      local NVM_OUTPUT
+      NVM_OUTPUT="$(echo "$NVM_LS_REMOTE_OUTPUT
+$NVM_LS_REMOTE_IOJS_OUTPUT" | grep -v "N/A" | sed '/^$/d')"
+      if [ -n "$NVM_OUTPUT" ]; then
+        nvm_print_versions "$NVM_OUTPUT"
+        return $NVM_LS_REMOTE_EXIT_CODE || $NVM_LS_REMOTE_IOJS_EXIT_CODE
+      else
+        nvm_print_versions "N/A"
+        return 3
+      fi
     ;;
     "current" )
       nvm_version current

--- a/nvm.sh
+++ b/nvm.sh
@@ -1115,17 +1115,33 @@ nvm() {
       return $NVM_LS_EXIT_CODE
     ;;
     "ls-remote" | "list-remote" )
-      local NVM_LS_REMOTE_OUTPUT
-      local NVM_LS_REMOTE_EXIT_CODE
-      NVM_LS_REMOTE_OUTPUT=$(nvm_ls_remote "$2")
-      NVM_LS_REMOTE_EXIT_CODE=$?
-      nvm_print_versions "$NVM_LS_REMOTE_OUTPUT"
+      local PATTERN
+      PATTERN="$2"
+      local NVM_FLAVOR
+      case "_$PATTERN" in
+        "_$(nvm_iojs_prefix)" | "_$(nvm_node_prefix)" )
+          NVM_FLAVOR="$PATTERN"
+          PATTERN="$3"
+        ;;
+      esac
 
-      local NVM_LS_REMOTE_IOJS_OUTPUT
+      local NVM_LS_REMOTE_EXIT_CODE
+      NVM_LS_REMOTE_EXIT_CODE=0
+      if [ "_$NVM_FLAVOR" != "_$(nvm_iojs_prefix)" ]; then
+        local NVM_LS_REMOTE_OUTPUT
+        NVM_LS_REMOTE_OUTPUT=$(nvm_ls_remote "$PATTERN")
+        NVM_LS_REMOTE_EXIT_CODE=$?
+        nvm_print_versions "$NVM_LS_REMOTE_OUTPUT"
+      fi
+
       local NVM_LS_REMOTE_IOJS_EXIT_CODE
-      NVM_LS_REMOTE_IOJS_OUTPUT=$(nvm_ls_remote_iojs "$2")
-      NVM_LS_REMOTE_IOJS_EXIT_CODE=$?
-      nvm_print_versions "$NVM_LS_REMOTE_IOJS_OUTPUT"
+      NVM_LS_REMOTE_IOJS_EXIT_CODE=0
+      if [ "_$NVM_FLAVOR" != "_$(nvm_node_prefix)" ]; then
+        local NVM_LS_REMOTE_IOJS_OUTPUT
+        NVM_LS_REMOTE_IOJS_OUTPUT=$(nvm_ls_remote_iojs "$PATTERN")
+        NVM_LS_REMOTE_IOJS_EXIT_CODE=$?
+        nvm_print_versions "$NVM_LS_REMOTE_IOJS_OUTPUT"
+      fi
 
       return $NVM_LS_REMOTE_EXIT_CODE && $NVM_LS_REMOTE_IOJS_EXIT_CODE
     ;;

--- a/nvm.sh
+++ b/nvm.sh
@@ -264,7 +264,13 @@ nvm_num_version_groups() {
 }
 
 nvm_strip_path() {
-  echo "$1" | command sed -e "s#$NVM_DIR/[^/]*$2[^:]*:##g" -e "s#:$NVM_DIR/[^/]*$2[^:]*##g" -e "s#$NVM_DIR/[^/]*$2[^:]*##g"
+  echo "$1" | command sed \
+    -e "s#$NVM_DIR/[^/]*$2[^:]*:##g" \
+    -e "s#:$NVM_DIR/[^/]*$2[^:]*##g" \
+    -e "s#$NVM_DIR/[^/]*$2[^:]*##g" \
+    -e "s#$NVM_DIR/versions/[^/]*/[^/]*$2[^:]*:##g" \
+    -e "s#:$NVM_DIR/versions/[^/]*/[^/]*$2[^:]*##g" \
+    -e "s#$NVM_DIR/versions/[^/]*/[^/]*$2[^:]*##g"
 }
 
 nvm_prepend_path() {

--- a/nvm.sh
+++ b/nvm.sh
@@ -350,6 +350,9 @@ nvm_resolve_alias() {
 nvm_iojs_prefix() {
   echo "iojs"
 }
+nvm_node_prefix() {
+  echo "node"
+}
 
 nvm_ls() {
   local PATTERN
@@ -1194,7 +1197,7 @@ nvm() {
     ;;
     "unload" )
       unset -f nvm nvm_print_versions nvm_checksum \
-        nvm_iojs_prefix \
+        nvm_iojs_prefix nvm_node_prefix \
         nvm_ls_remote nvm_ls nvm_remote_version \
         nvm_version nvm_rc_version \
         nvm_version_greater nvm_version_greater_than_or_equal_to \

--- a/nvm.sh
+++ b/nvm.sh
@@ -144,6 +144,8 @@ nvm_version_dir() {
   NVM_WHICH_DIR="$1"
   if [ -z "$NVM_WHICH_DIR" ] || [ "_$NVM_WHICH_DIR" = "_new" ]; then
     echo "$NVM_DIR/versions/node"
+  elif [ "_$NVM_WHICH_DIR" = "_iojs" ]; then
+    echo "$NVM_DIR/versions/io.js"
   elif [ "_$NVM_WHICH_DIR" = "_old" ]; then
     echo "$NVM_DIR"
   else

--- a/nvm.sh
+++ b/nvm.sh
@@ -289,9 +289,11 @@ nvm_ls_current() {
   NVM_LS_CURRENT_NODE_PATH="$(command which node 2> /dev/null)"
   if [ $? -ne 0 ]; then
     echo 'none'
+  elif nvm_tree_contains_path "$(nvm_version_dir iojs)" "$NVM_LS_CURRENT_NODE_PATH"; then
+    echo "$(nvm_add_iojs_prefix $(iojs --version 2>/dev/null))"
   elif nvm_tree_contains_path "$NVM_DIR" "$NVM_LS_CURRENT_NODE_PATH"; then
     local VERSION
-    VERSION="$(node -v 2>/dev/null)"
+    VERSION="$(node --version 2>/dev/null)"
     if [ "$VERSION" = "v0.6.21-pre" ]; then
       echo "v0.6.21"
     else

--- a/nvm.sh
+++ b/nvm.sh
@@ -211,7 +211,13 @@ nvm_normalize_version() {
 }
 
 nvm_ensure_version_prefix() {
-  echo "$1" | command sed -e 's/^\([0-9]\)/v\1/g'
+  local NVM_VERSION
+  NVM_VERSION="$(nvm_strip_iojs_prefix "$1" | command sed -e 's/^\([0-9]\)/v\1/g')"
+  if nvm_is_iojs_version "$1"; then
+    echo "$(nvm_add_iojs_prefix "$NVM_VERSION")"
+  else
+    echo "$NVM_VERSION"
+  fi
 }
 
 nvm_format_version() {

--- a/nvm.sh
+++ b/nvm.sh
@@ -1076,11 +1076,22 @@ nvm() {
         fi
       fi
 
-      echo "Running node $VERSION"
+      local NVM_IOJS
+      if nvm_is_iojs_version "$VERSION"; then
+        NVM_IOJS=true
+      fi
+
       local ARGS
       ARGS="$@"
       local OUTPUT
-      OUTPUT="$(nvm use "$VERSION" >/dev/null && node "$ARGS")"
+
+      if [ "$NVM_IOJS" = true ]; then
+        echo "Running io.js $(nvm_strip_iojs_prefix "$VERSION")"
+        OUTPUT="$(nvm use "$VERSION" >/dev/null && iojs "$ARGS")"
+      else
+        echo "Running node $VERSION"
+        OUTPUT="$(nvm use "$VERSION" >/dev/null && node "$ARGS")"
+      fi
       local EXIT_CODE
       EXIT_CODE="$?"
       echo "$OUTPUT"

--- a/nvm.sh
+++ b/nvm.sh
@@ -846,10 +846,6 @@ nvm() {
         shift
       fi
 
-      if [ "_$NVM_OS" = "_freebsd" ]; then
-        nobinary=1
-      fi
-
       provided_version="$1"
 
       if [ -z "$provided_version" ]; then
@@ -903,6 +899,18 @@ nvm() {
         return 3
       fi
 
+      local NVM_IOJS
+      if nvm_is_iojs_version "$VERSION"; then
+        NVM_IOJS=true
+      fi
+
+      if [ "_$NVM_OS" = "_freebsd" ]; then
+        # node.js and io.js do not have a FreeBSD binary
+        nobinary=1
+      elif [ "_$NVM_OS" = "_sunos" ] && [ "$NVM_IOJS" = true ]; then
+        # io.js does not have a SunOS binary
+        nobinary=1
+      fi
       # skip binary install if "nobinary" option specified.
       if [ $nobinary -ne 1 ] && nvm_install_node_binary "$VERSION" "$REINSTALL_PACKAGES_FROM"; then
         if nvm use "$VERSION" \

--- a/nvm.sh
+++ b/nvm.sh
@@ -354,6 +354,10 @@ nvm_node_prefix() {
   echo "node"
 }
 
+nvm_is_iojs_version() {
+  [ "_$(echo "$1" | cut -c1-5)" = "_iojs-" ]
+}
+
 nvm_ls() {
   local PATTERN
   PATTERN="$1"
@@ -1198,6 +1202,7 @@ nvm() {
     "unload" )
       unset -f nvm nvm_print_versions nvm_checksum \
         nvm_iojs_prefix nvm_node_prefix \
+        nvm_is_iojs_version \
         nvm_ls_remote nvm_ls nvm_remote_version \
         nvm_version nvm_rc_version \
         nvm_version_greater nvm_version_greater_than_or_equal_to \

--- a/nvm.sh
+++ b/nvm.sh
@@ -913,7 +913,18 @@ nvm() {
         shift
       fi
 
-      VERSION="$(nvm_remote_version "$provided_version")"
+      case "_$provided_version" in
+        "_$(nvm_iojs_prefix)" | "_io.js")
+          VERSION="$(nvm_add_iojs_prefix $(nvm_ls_remote_iojs | tail -n1))"
+        ;;
+        "_$(nvm_node_prefix)")
+          VERSION="$(nvm_ls_remote stable)"
+        ;;
+        *)
+          VERSION="$(nvm_remote_version "$provided_version")"
+        ;;
+      esac
+
       ADDITIONAL_PARAMETERS=''
       local PROVIDED_REINSTALL_PACKAGES_FROM
       local REINSTALL_PACKAGES_FROM
@@ -940,6 +951,11 @@ nvm() {
         return 5
       fi
 
+      local NVM_IOJS
+      if nvm_is_iojs_version "$VERSION"; then
+        NVM_IOJS=true
+      fi
+
       local VERSION_PATH
       VERSION_PATH="$(nvm_version_path "$VERSION")"
       if [ -d "$VERSION_PATH" ]; then
@@ -953,11 +969,6 @@ nvm() {
       if [ "_$VERSION" = "_N/A" ]; then
         echo "Version '$provided_version' not found - try \`nvm ls-remote\` to browse available versions." >&2
         return 3
-      fi
-
-      local NVM_IOJS
-      if nvm_is_iojs_version "$VERSION" || [ "_$VERSION" = "_$(nvm_iojs_prefix)" ]; then
-        NVM_IOJS=true
       fi
 
       if [ "_$NVM_OS" = "_freebsd" ]; then

--- a/nvm.sh
+++ b/nvm.sh
@@ -347,6 +347,10 @@ nvm_resolve_alias() {
   return 2
 }
 
+nvm_iojs_prefix() {
+  echo "iojs"
+}
+
 nvm_ls() {
   local PATTERN
   PATTERN="$1"
@@ -1189,7 +1193,12 @@ nvm() {
       echo "0.22.2"
     ;;
     "unload" )
-      unset -f nvm nvm_print_versions nvm_checksum nvm_ls_remote nvm_ls nvm_remote_version nvm_version nvm_rc_version nvm_version_greater nvm_version_greater_than_or_equal_to nvm_supports_source_options > /dev/null 2>&1
+      unset -f nvm nvm_print_versions nvm_checksum \
+        nvm_iojs_prefix \
+        nvm_ls_remote nvm_ls nvm_remote_version \
+        nvm_version nvm_rc_version \
+        nvm_version_greater nvm_version_greater_than_or_equal_to \
+        nvm_supports_source_options > /dev/null 2>&1
       unset RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_DIR NVM_CD_FLAGS > /dev/null 2>&1
     ;;
     * )

--- a/nvm.sh
+++ b/nvm.sh
@@ -207,8 +207,12 @@ nvm_remote_version() {
   local PATTERN
   PATTERN="$1"
   local VERSION
-  VERSION="$(nvm_ls_remote "$PATTERN" | tail -n1)"
-  echo "$VERSION"
+  if nvm_is_iojs_version "$PATTERN"; then
+    VERSION="$(nvm_ls_remote_iojs "$PATTERN")"
+  else
+    VERSION="$(nvm_ls_remote "$PATTERN")"
+  fi
+  echo "$VERSION" | tail -n1
 
   if [ "_$VERSION" = '_N/A' ]; then
     return 3

--- a/nvm.sh
+++ b/nvm.sh
@@ -358,6 +358,10 @@ nvm_is_iojs_version() {
   [ "_$(echo "$1" | cut -c1-5)" = "_iojs-" ]
 }
 
+nvm_add_iojs_prefix() {
+  command echo "$(nvm_iojs_prefix)-$(nvm_ensure_version_prefix "$(nvm_strip_iojs_prefix "$1")")"
+}
+
 nvm_strip_iojs_prefix() {
   local NVM_IOJS_PREFIX
   NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
@@ -1212,7 +1216,7 @@ nvm() {
     "unload" )
       unset -f nvm nvm_print_versions nvm_checksum \
         nvm_iojs_prefix nvm_node_prefix \
-        nvm_strip_iojs_prefix \
+        nvm_add_iojs_prefix nvm_strip_iojs_prefix \
         nvm_is_iojs_version \
         nvm_ls_remote nvm_ls nvm_remote_version \
         nvm_version nvm_rc_version \

--- a/nvm.sh
+++ b/nvm.sh
@@ -49,6 +49,10 @@ nvm_has_system_node() {
   [ "$(nvm deactivate >/dev/null 2>&1 && command -v node)" != '' ]
 }
 
+nvm_has_system_iojs() {
+  [ "$(nvm deactivate >/dev/null 2>&1 && command -v iojs)" != '' ]
+}
+
 # Make zsh glob matching behave same as bash
 # This fixes the "zsh: no matches found" errors
 if nvm_has "unsetopt"; then
@@ -463,7 +467,7 @@ nvm_ls() {
     fi
   fi
 
-  if nvm_has_system_node; then
+  if nvm_has_system_node || nvm_has_system_iojs; then
     if [ -z "$PATTERN" ] || [ "_$PATTERN" = "_v" ]; then
       VERSIONS="$VERSIONS$(command printf '\n%s' 'system')"
     elif [ "$PATTERN" = 'system' ]; then
@@ -1095,6 +1099,9 @@ nvm() {
         if nvm_has_system_node && nvm deactivate >/dev/null 2>&1; then
           echo "Now using system version of node: $(node -v 2>/dev/null)."
           return
+        elif nvm_has_system_iojs && nvm deactivate >/dev/null 2>&1; then
+          echo "Now using system version of io.js: $(iojs --version 2>/dev/null)."
+          return
         else
           echo "System version of node not found." >&2
           return 127
@@ -1274,7 +1281,7 @@ nvm() {
       fi
 
       if [ "_$VERSION" = '_system' ]; then
-        if nvm_has_system_node >/dev/null 2>&1; then
+        if nvm_has_system_iojs >/dev/null 2>&1 || nvm_has_system_node >/dev/null 2>&1; then
           local NVM_BIN
           NVM_BIN="$(nvm use system >/dev/null 2>&1 && command which node)"
           if [ -n "$NVM_BIN" ]; then
@@ -1373,8 +1380,8 @@ nvm() {
 
       local INSTALLS
       if [ "_$PROVIDED_VERSION" = "_system" ]; then
-        if ! nvm_has_system_node; then
-          echo 'No system version of node detected.' >&2
+        if ! nvm_has_system_node && ! nvm_has_system_iojs; then
+          echo 'No system version of node or io.js detected.' >&2
           return 3
         fi
         INSTALLS=$(nvm deactivate > /dev/null && npm list -g --depth=0 | command tail -n +2 | command grep -o -e ' [^@]*' | command cut -c 2- | command grep -v npm | command xargs)

--- a/nvm.sh
+++ b/nvm.sh
@@ -199,6 +199,11 @@ nvm_version() {
     return $?
   fi
 
+  case "_$PATTERN" in
+    "_$(nvm_node_prefix)" | "_$(nvm_node_prefix)-")
+      PATTERN="stable"
+    ;;
+  esac
   VERSION="$(nvm_ls "$PATTERN" | tail -n1)"
   if [ -z "$VERSION" ] || [ "_$VERSION" = "_N/A" ]; then
     echo "N/A"

--- a/nvm.sh
+++ b/nvm.sh
@@ -358,6 +358,16 @@ nvm_is_iojs_version() {
   [ "_$(echo "$1" | cut -c1-5)" = "_iojs-" ]
 }
 
+nvm_strip_iojs_prefix() {
+  local NVM_IOJS_PREFIX
+  NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  if [ "_$1" = "_$NVM_IOJS_PREFIX" ]; then
+    echo
+  else
+    echo "$1" | command sed "s/^$NVM_IOJS_PREFIX-//"
+  fi
+}
+
 nvm_ls() {
   local PATTERN
   PATTERN="$1"
@@ -1202,6 +1212,7 @@ nvm() {
     "unload" )
       unset -f nvm nvm_print_versions nvm_checksum \
         nvm_iojs_prefix nvm_node_prefix \
+        nvm_strip_iojs_prefix \
         nvm_is_iojs_version \
         nvm_ls_remote nvm_ls nvm_remote_version \
         nvm_version nvm_rc_version \

--- a/nvm.sh
+++ b/nvm.sh
@@ -164,6 +164,8 @@ nvm_version_path() {
   if [ -z "$VERSION" ]; then
     echo "version is required" >&2
     return 3
+  elif nvm_is_iojs_version "$VERSION"; then
+    echo "$(nvm_version_dir iojs)/$(nvm_strip_iojs_prefix "$VERSION")"
   elif nvm_version_greater 0.12.0 "$VERSION"; then
     echo "$(nvm_version_dir old)/$VERSION"
   else
@@ -515,14 +517,14 @@ nvm_print_versions() {
   local NVM_CURRENT
   NVM_CURRENT=$(nvm_ls_current)
   echo "$1" | while read VERSION; do
-    if [ "$VERSION" = "$NVM_CURRENT" ]; then
-      FORMAT='\033[0;32m-> %9s\033[0m'
-    elif [ -d "$(nvm_version_path "$VERSION" 2> /dev/null)" ]; then
-      FORMAT='\033[0;34m%12s\033[0m'
+    if [ "_$VERSION" = "_$NVM_CURRENT" ]; then
+      FORMAT='\033[0;32m-> %12s\033[0m'
     elif [ "$VERSION" = "system" ]; then
-      FORMAT='\033[0;33m%12s\033[0m'
+      FORMAT='\033[0;33m%15s\033[0m'
+    elif [ -d "$(nvm_version_path "$VERSION" 2> /dev/null)" ]; then
+      FORMAT='\033[0;34m%15s\033[0m'
     else
-      FORMAT='%12s'
+      FORMAT='%15s'
     fi
     printf "$FORMAT\n" $VERSION
   done

--- a/test/fast/Listing versions/Running "nvm ls node_" should return a nonzero exit code when not found
+++ b/test/fast/Listing versions/Running "nvm ls node_" should return a nonzero exit code when not found
@@ -2,6 +2,6 @@
 
 . ../../../nvm.sh
 
-nvm ls node
+nvm ls node_
 [ "$?" = "3" ]
 

--- a/test/fast/Listing versions/Running "nvm ls" should display all installed versions.
+++ b/test/fast/Listing versions/Running "nvm ls" should display all installed versions.
@@ -8,11 +8,17 @@ mkdir ../../../v0.0.9
 mkdir ../../../v0.3.1
 mkdir ../../../v0.3.3
 mkdir ../../../v0.3.9
+mkdir -p ../../../versions/node/v0.12.87
+mkdir -p ../../../versions/node/v0.12.9
+mkdir -p ../../../versions/io.js/v0.1.2
+mkdir -p ../../../versions/io.js/v0.10.2
 
 # The result should contain the version numbers.
-nvm ls | grep v0.0.1 &&
-nvm ls | grep v0.0.3 &&
-nvm ls | grep v0.0.9 &&
-nvm ls | grep v0.3.1 &&
-nvm ls | grep v0.3.3 &&
-nvm ls | grep v0.3.9
+nvm ls | grep v0.0.1 >/dev/null &&
+nvm ls | grep v0.0.3 >/dev/null &&
+nvm ls | grep v0.0.9 >/dev/null &&
+nvm ls | grep v0.3.1 >/dev/null &&
+nvm ls | grep v0.3.3 >/dev/null &&
+nvm ls | grep v0.3.9 >/dev/null &&
+nvm ls | grep v0.12.87 >/dev/null &&
+nvm ls | grep iojs-v0.1.2 >/dev/null

--- a/test/fast/Unit tests/nvm_add_iojs_prefix
+++ b/test/fast/Unit tests/nvm_add_iojs_prefix
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+[ "_$(nvm_add_iojs_prefix 1)" = "_iojs-v1" ] || die '"nvm_add_iojs_prefix 1" did not return "iojs-v1"'
+[ "_$(nvm_add_iojs_prefix iojs-1)" = "_iojs-v1" ] || die '"nvm_add_iojs_prefix iojs-1" did not return "iojs-v1"'
+[ "_$(nvm_add_iojs_prefix iojs-1.2.3)" = "_iojs-v1.2.3" ] || die '"nvm_add_iojs_prefix iojs-1.2.3" did not return "iojs-v1.2.3"'

--- a/test/fast/Unit tests/nvm_ensure_version_prefix
+++ b/test/fast/Unit tests/nvm_ensure_version_prefix
@@ -7,3 +7,6 @@ die () { echo $@ ; exit 1; }
 [ "_$(nvm_ensure_version_prefix 1)" = "_v1" ] || die '"nvm_ensure_version_prefix 1" did not return "v1"'
 [ "_$(nvm_ensure_version_prefix v1)" = "_v1" ] || die '"nvm_ensure_version_prefix v1" did not return "v1"'
 [ "_$(nvm_ensure_version_prefix foo)" = "_foo" ] || die '"nvm_ensure_version_prefix foo" did not return "foo"'
+
+[ "_$(nvm_ensure_version_prefix iojs-1)" = "_iojs-v1" ] || die '"nvm_ensure_version_prefix iojs-1" did not return "iojs-v1"'
+[ "_$(nvm_ensure_version_prefix iojs-v1)" = "_iojs-v1" ] || die '"nvm_ensure_version_prefix iojs-v1" did not return "iojs-v1"'

--- a/test/fast/Unit tests/nvm_has_system_iojs
+++ b/test/fast/Unit tests/nvm_has_system_iojs
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+cleanup () {
+  rm ../../../versions/io.js/v0.1.2/node
+  rm ../../../versions/io.js/v0.1.2/iojs
+  rmdir ../../../versions/io.js/v0.1.2
+}
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+mkdir ../../../versions/io.js/v0.1.2
+touch ../../../versions/io.js/v0.1.2/node
+touch ../../../versions/io.js/v0.1.2/iojs
+
+nvm use iojs-v0.1.2
+
+if command -v iojs; then
+  nvm_has_system_iojs
+else
+  ! nvm_has_system_iojs
+fi
+
+nvm deactivate /dev/null 2>&1
+
+if command -v iojs; then
+  nvm_has_system_iojs
+else
+  ! nvm_has_system_iojs
+fi
+

--- a/test/fast/Unit tests/nvm_iojs_prefix
+++ b/test/fast/Unit tests/nvm_iojs_prefix
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+[ "$(nvm_iojs_prefix)" = "iojs" ] || die '"nvm_iojs_prefix" did not return the string "iojs". why did this fail?!'

--- a/test/fast/Unit tests/nvm_is_iojs_version
+++ b/test/fast/Unit tests/nvm_is_iojs_version
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+nvm_is_iojs_version 'iojs-' || die '"nvm_is_iojs_version iojs- was not true'
+nvm_is_iojs_version 'iojs-foo' || die '"nvm_is_iojs_version iojs- was not true'
+! nvm_is_iojs_version 'iojs' || die '"nvm_is_iojs_version iojs was not false'
+! nvm_is_iojs_version 'v1.0.0' || die '"nvm_is_iojs_version v1.0.0" was not false'

--- a/test/fast/Unit tests/nvm_ls_remote_iojs
+++ b/test/fast/Unit tests/nvm_ls_remote_iojs
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+die () { echo $@ ; cleanup ; exit 1; }
+
+cleanup() {
+  unset -f nvm_download
+}
+
+. ../../../nvm.sh
+
+# sample output at the time the test was written
+nvm_download() {
+  echo 'version	date	files	npm	v8	uv	zlib	openssl	modules'
+  echo 'v1.0.1	2015-01-14	linux-armv7l,linux-x64,linux-x86,osx-x64-tar,win-x64-exe,win-x64-msi,win-x86-exe,win-x86-msi'
+  echo 'v1.0.0	2015-01-14	linux-armv7l,linux-x64,linux-x86,osx-x64-tar,win-x64-exe,win-x64-msi,win-x86-exe,win-x86-msi'
+}
+
+OUTPUT="$(nvm_ls_remote_iojs foo)"
+EXIT_CODE="$(nvm_ls_remote_iojs foo >/dev/null 2>&1 ; echo $?)"
+[ "_$OUTPUT" = "_N/A" ] || die "nonexistent version did not report N/A"
+[ "_$EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $EXIT_CODE"
+
+OUTPUT="$(nvm_ls_remote_iojs)"
+EXPECTED_OUTPUT="$(nvm_download | \egrep -o 'v[0-9]+\.[0-9]+\.[0-9]+' | sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n | sed -e 's/^/iojs-/')"
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "bare nvm_ls_remote_iojs did not output expected sorted versions; got $(echo "$OUTPUT") expected $(echo "$EXPECTED_OUTPUT")"
+
+OUTPUT="$(nvm_ls_remote_iojs 1.0)"
+EXPECTED_OUTPUT="iojs-v1.0.0
+iojs-v1.0.1"
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_ls_remote_iojs 1.0 did not output 1.0.x versions; got $OUTPUT"
+
+cleanup
+

--- a/test/fast/Unit tests/nvm_node_prefix
+++ b/test/fast/Unit tests/nvm_node_prefix
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+[ "$(nvm_node_prefix)" = "node" ] || die '"nvm_node_prefix" did not return the string "node". why did this fail?!'

--- a/test/fast/Unit tests/nvm_remote_version
+++ b/test/fast/Unit tests/nvm_remote_version
@@ -3,7 +3,7 @@
 die () { echo $@ ; cleanup ; exit 1; }
 
 cleanup() {
-  unset -f nvm_ls_remote
+  unset -f nvm_ls_remote nvm_ls_remote_iojs
 }
 
 . ../../../nvm.sh
@@ -11,25 +11,42 @@ cleanup() {
 nvm_ls_remote() {
   echo "N/A"
 }
-
 OUTPUT="$(nvm_remote_version foo)"
 EXIT_CODE="$(nvm_remote_version foo >/dev/null 2>&1 ; echo $?)"
-
 [ "_$OUTPUT" = "_N/A" ] || die "nonexistent version did not report N/A"
 [ "_$EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $EXIT_CODE"
+
+nvm_ls_remote_iojs() {
+  echo "N/A"
+}
+OUTPUT="$(nvm_remote_version iojs-foo)"
+EXIT_CODE="$(nvm_remote_version iojs-foo >/dev/null 2>&1 ; echo $?)"
+[ "_$OUTPUT" = "_N/A" ] || die "nonexistent version did not report N/A"
+[ "_$EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $EXIT_CODE"
+
 
 nvm_ls_remote() {
   echo "test output"
   echo "more test output"
   echo "pattern received: _$1_"
 }
-
 OUTPUT="$(nvm_remote_version foo)"
 EXIT_CODE="$(nvm_remote_version foo >/dev/null 2>&1 ; echo $?)"
-
 [ "_$OUTPUT" = "_pattern received: _foo_" ] \
   || die "nvm_remote_version foo did not return last line only of nvm_ls_remote foo; got $OUTPUT"
 [ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_version foo did not exit with 0, got $EXIT_CODE"
+
+nvm_ls_remote_iojs() {
+  echo "test iojs output"
+  echo "more iojs test output"
+  echo "iojs pattern received: _$1_"
+
+}
+OUTPUT="$(nvm_remote_version iojs-foo)"
+EXIT_CODE="$(nvm_remote_version iojs-foo >/dev/null 2>&1 ; echo $?)"
+[ "_$OUTPUT" = "_iojs pattern received: _iojs-foo_" ] \
+  || die "nvm_remote_version iojs-foo did not return last line only of nvm_ls_remote_iojs foo; got $OUTPUT"
+[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_version iojs-foo did not exit with 0, got $EXIT_CODE"
 
 cleanup
 

--- a/test/fast/Unit tests/nvm_strip_iojs_prefix
+++ b/test/fast/Unit tests/nvm_strip_iojs_prefix
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+[ "_$(nvm_strip_iojs_prefix iojs)" = "_" ] || die '"nvm_strip_iojs_prefix iojs" did not return an empty string'
+[ "_$(nvm_strip_iojs_prefix iojs-)" = "_" ] || die '"nvm_strip_iojs_prefix iojs-" did not return an empty string'
+[ "_$(nvm_strip_iojs_prefix iojs-foo)" = "_foo" ] || die '"nvm_strip_iojs_prefix iojs-foo" did not return "foo"'
+[ "_$(nvm_strip_iojs_prefix iojsfoo)" = "_iojsfoo" ] || die '"nvm_strip_iojs_prefix iojsfoo" did not return "iojsfoo"'

--- a/test/fast/Unit tests/nvm_strip_path
+++ b/test/fast/Unit tests/nvm_strip_path
@@ -4,7 +4,7 @@ die () { echo $@ ; exit 1; }
 
 . ../../../nvm.sh
 
-TEST_PATH=$NVM_DIR/v0.10.5/bin:/usr/bin:$NVM_DIR/v0.11.5/bin:$NVM_DIR/v0.9.5/bin:/usr/local/bin:$NVM_DIR/v0.2.5/bin
+TEST_PATH=$NVM_DIR/v0.10.5/bin:/usr/bin:$NVM_DIR/v0.11.5/bin:$NVM_DIR/v0.9.5/bin:/usr/local/bin:$NVM_DIR/v0.2.5/bin:$NVM_DIR/versions/node/v0.12.0/bin:$NVM_DIR/versions/io.js/v1.0.0/bin
 
 STRIPPED_PATH=`nvm_strip_path "$TEST_PATH" "/bin"`
 

--- a/test/fast/Unit tests/nvm_version
+++ b/test/fast/Unit tests/nvm_version
@@ -29,8 +29,9 @@ nvm_ls() {
   echo "line 2"
   echo "pattern: $1"
 }
-
 [ "_$(nvm_version foo)" = "_pattern: foo" ] || die '"nvm_version foo" did not pass the pattern to "nvm_ls", or return the last line'
+[ "_$(nvm_version node)" = "_pattern: stable" ] || die '"nvm_version node" did not pass "stable" to "nvm_ls"'
+[ "_$(nvm_version node-)" = "_pattern: stable" ] || die '"nvm_version node-" did not pass "stable" to "nvm_ls"'
 
 nvm_ls() { echo "N/A"; }
 OUTPUT="$(nvm_version foo)"

--- a/test/fast/Unit tests/nvm_version
+++ b/test/fast/Unit tests/nvm_version
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+die () { echo $@ ; cleanup ; exit 1; }
+cleanup () {
+  unset -f nvm_ls_current nvm_ls
+}
+
+. ../../../nvm.sh
+
+nvm_ls_current() {
+  echo "CURRENT!"
+  return 7
+}
+
+OUTPUT="$(nvm_version current)"
+EXPECTED_OUTPUT="CURRENT!"
+EXIT_CODE="$(nvm_version current 2>&1 >/dev/null ; echo $?)"
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die '"nvm_version current" did not return nvm_ls_current output'
+[ "_$EXIT_CODE" = "_7" ] || die '"nvm_version current" did not return nvm_ls_current exit code'
+
+OUTPUT="$(nvm_version)"
+EXPECTED_OUTPUT="CURRENT!"
+EXIT_CODE="$(nvm_version 2>&1 >/dev/null ; echo $?)"
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die '"nvm_version" did not return nvm_ls_current output'
+[ "_$EXIT_CODE" = "_7" ] || die '"nvm_version" did not return nvm_ls_current exit code'
+
+nvm_ls() {
+  echo "line 1"
+  echo "line 2"
+  echo "pattern: $1"
+}
+
+[ "_$(nvm_version foo)" = "_pattern: foo" ] || die '"nvm_version foo" did not pass the pattern to "nvm_ls", or return the last line'
+
+nvm_ls() { echo "N/A"; }
+OUTPUT="$(nvm_version foo)"
+EXPECTED_OUTPUT="N/A"
+EXIT_CODE="$(nvm_version foo 2>&1 >/dev/null ; echo $?)"
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die '"nvm_version" did not return N/A when nvm_ls returns N/A'
+[ "_$EXIT_CODE" = "_3" ] || die '"nvm_version" returning N/A did not exit code with code 3'
+
+nvm_ls() { echo; }
+OUTPUT="$(nvm_version foo)"
+EXPECTED_OUTPUT="N/A"
+EXIT_CODE="$(nvm_version foo 2>&1 >/dev/null ; echo $?)"
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die '"nvm_version" did not return N/A when nvm_ls returns nothing'
+[ "_$EXIT_CODE" = "_3" ] || die '"nvm_version" returning N/A did not exit code with code 3'

--- a/test/fast/Unit tests/nvm_version_dir
+++ b/test/fast/Unit tests/nvm_version_dir
@@ -5,6 +5,7 @@ die () { echo $@ ; exit 1; }
 . ../../../nvm.sh
 
 [ "$(nvm_version_dir)" = "$NVM_DIR/versions/node" ] || die '"nvm_version_dir" did not return new dir path'
+[ "$(nvm_version_dir iojs)" = "$NVM_DIR/versions/io.js" ] || die '"nvm_version_dir iojs" did not return iojs dir path'
 [ "$(nvm_version_dir new)" = "$(nvm_version_dir)" ] || die '"nvm_version_dir new" did not return new dir path'
 [ "$(nvm_version_dir old)" = "$NVM_DIR" ] || die '"nvm_version_dir old" did not return old dir path'
 [ "$(nvm_version_dir foo 2>&1)" = "unknown version dir" ] || die '"nvm_version_dir foo" did not error out'

--- a/test/fast/Unit tests/nvm_version_path
+++ b/test/fast/Unit tests/nvm_version_path
@@ -8,4 +8,5 @@ die () { echo $@ ; exit 1; }
 [ "$(nvm_version_path 2>&1)" = "version is required" ] || die '"nvm_version_path" did not error out'
 [ "$(nvm_version_path v0.11.0)" = "$NVM_DIR/v0.11.0" ] || die 'old version has the wrong path'
 [ "$(nvm_version_path v0.12.0)" = "$NVM_DIR/versions/node/v0.12.0" ] || die 'new version has the wrong path'
+[ "$(nvm_version_path iojs-v0.12.0)" = "$NVM_DIR/versions/io.js/v0.12.0" ] || die 'iojs version has the wrong path'
 

--- a/test/installation/io.js/install already installed uses it
+++ b/test/installation/io.js/install already installed uses it
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+[ "$(nvm install invalid.invalid 2>&1)" = "Version 'invalid.invalid' not found - try \`nvm ls-remote\` to browse available versions." ] || die "nvm installing an invalid version did not print a nice error message"
+
+# Remove the stuff we're clobbering.
+[ -e ../../../versions/io.js/v1.0.0 ] && rm -R ../../../versions/io.js/v1.0.0
+[ -e ../../../versions/io.js/v1.0.1 ] && rm -R ../../../versions/io.js/v1.0.1
+
+# Install from binary
+nvm install iojs-v1.0.0
+nvm install iojs-v1.0.1
+
+nvm use iojs-v1.0.0
+
+node --version | grep v1.0.0 || die "precondition failed: iojs node doesn't start at v1.0.0"
+iojs --version | grep v1.0.0 || die "precondition failed: iojs binary doesn't start at v1.0.0"
+
+nvm install iojs-v1.0.1
+
+node --version | grep v1.0.1 || die "nvm install on already installed version doesn't use it (node binary)"
+iojs --version | grep v1.0.1 || die "nvm install on already installed version doesn't use it (iojs binary)"
+

--- a/test/installation/io.js/install from binary
+++ b/test/installation/io.js/install from binary
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+NVM_TEST_VERSION="v1.0.0"
+NVM_PREFIXED_TEST_VERSION="iojs-$NVM_TEST_VERSION"
+
+# Remove the stuff we're clobbering.
+[ -e ../../../$NVM_TEST_VERSION ] && rm -R ../../../$NVM_TEST_VERSION
+
+# Install from binary
+nvm install $NVM_PREFIXED_TEST_VERSION || die "install $NVM_PREFIXED_TEST_VERSION failed"
+
+# Check
+[ -d ../../../versions/io.js/$NVM_TEST_VERSION ]
+nvm run $NVM_PREFIXED_TEST_VERSION --version | grep $NVM_TEST_VERSION || die "'nvm run $NVM_PREFIXED_TEST_VERSION --version | grep $NVM_TEST_VERSION' failed"
+

--- a/test/installation/io.js/install two versions and use the latest one
+++ b/test/installation/io.js/install two versions and use the latest one
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+# Remove the stuff we're clobbering.
+[ -e ../../../versions/io.js/v1.0.0 ] && rm -R ../../../versions/io.js/v1.0.0
+[ -e ../../../versions/io.js/v1.0.1 ] && rm -R ../../../versions/io.js/v1.0.1
+
+# Install from binary
+nvm install iojs-v1.0.0 || die "'nvm install iojs-v1.0.0' failed"
+nvm i iojs-v1.0.1 || die "'nvm i iojs-v1.0.1' failed"
+
+# Check
+[ -d ../../../versions/io.js/v1.0.0 ] || die "iojs v1.0.0 didn't exist"
+[ -d ../../../versions/io.js/v1.0.1 ] || die "iojs v1.0.1 didn't exist"
+
+# Use the first one
+nvm use iojs-1.0.0 || die "'nvm use iojs-1.0.0' failed"
+
+# Use the latest one
+nvm use iojs-1 || die "'nvm use iojs-1' failed"
+[ "_$(node --version)" = "_v1.0.1" ] || die "'node --version' was not v1.0.1, got: $(node --version)"
+[ "_$(iojs --version)" = "_v1.0.1" ] || die "'iojs --version' was not v1.0.1, got: $(iojs --version)"
+

--- a/test/installation/io.js/install version specified in .nvmrc from binary
+++ b/test/installation/io.js/install version specified in .nvmrc from binary
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+NVM_TEST_VERSION=v1.0.0
+NVM_PREFIXED_TEST_VERSION="iojs-$NVM_TEST_VERSION"
+VERSION_PATH="../../../versions/io.js/$NVM_TEST_VERSION"
+
+# Remove the stuff we're clobbering.
+[ -e $VERSION_PATH ] && rm -R $VERSION_PATH
+
+# Install from binary
+echo "$NVM_PREFIXED_TEST_VERSION" > .nvmrc
+
+nvm install || die "'nvm install' failed"
+
+# Check
+[ -d $VERSION_PATH ] || die "./$VERSION_PATH did not exist"
+nvm run $NVM_PREFIXED_TEST_VERSION --version | grep $NVM_TEST_VERSION \
+  || "'nvm run $NVM_PREFIXED_TEST_VERSION --version | grep $NVM_TEST_VERSION' failed"
+
+

--- a/test/installation/io.js/install while reinstalling packages
+++ b/test/installation/io.js/install while reinstalling packages
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+# Remove the stuff we're clobbering.
+[ -e ../../../versions/io.js/v1.0.0 ] && rm -R ../../../versions/io.js/v1.0.0
+[ -e ../../../versions/io.js/v1.0.1 ] && rm -R ../../../versions/io.js/v1.0.1
+
+# Install from binary
+nvm install iojs-v1.0.0
+
+# Check
+[ -d ../../../versions/io.js/v1.0.0 ] || die "nvm install iojs-v1.0.0 didn't install"
+
+node --version | grep v1.0.0 > /dev/null || die "nvm install didn't use iojs-v1.0.0"
+
+npm install -g is-nan@1.0.1 || die "npm install -g is-nan failed"
+npm list --global | grep is-nan > /dev/null || die "is-nan isn't installed"
+
+nvm ls iojs-1 | grep iojs-v1.0.0 > /dev/null || die "nvm ls iojs-1 didn't show iojs-v1.0.0"
+
+nvm install iojs-v1.0.1 --reinstall-packages-from=iojs-1.0.0 || die "nvm install iojs-v1.0.1 --reinstall-packages-from=iojs-1.0.0 failed"
+
+[ -d ../../../versions/io.js/v1.0.1 ] || die "nvm install iojs-v1.0.1 didn't install"
+
+nvm use iojs-1
+node --version | grep v1.0.1 > /dev/null || die "nvm use iojs-1 didn't use v1.0.1"
+
+npm list --global | grep is-nan > /dev/null || die "is-nan isn't installed"
+

--- a/test/installation/io.js/setup_dir
+++ b/test/installation/io.js/setup_dir
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ -f ".nvmrc" ]; then
+  mv .nvmrc .nvmrc.bak
+fi
+

--- a/test/installation/io.js/teardown_dir
+++ b/test/installation/io.js/teardown_dir
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+. ../../../nvm.sh
+nvm deactivate
+nvm uninstall iojs-v1.0.0
+
+if [ -f ".nvmrc" ]; then
+  rm .nvmrc
+fi
+
+if [ -f ".nvmrc.bak" ]; then
+  mv .nvmrc.bak .nvmrc
+fi
+

--- a/test/slow/node 0.6.21 should install 0.6.21-pre
+++ b/test/slow/node 0.6.21 should install 0.6.21-pre
@@ -5,6 +5,6 @@ die () { echo $@ ; exit 1; }
 . ../../nvm.sh
 
 nvm install 0.6.21 || die 'v0.6.21 installation failed'
-[ "$(node -v)" = "v0.6.21-pre" ] || die "v0.6.21-pre not installed with v0.6.21, got $(node -v)"
-[ "$(nvm current)" = "v0.6.21" ] || die "v0.6.21-pre not reported as v0.6.21, got $(nvm current)"
+[ "_$(node -v)" = "_v0.6.21-pre" ] || die "v0.6.21-pre not installed with v0.6.21, got $(node -v)"
+[ "_$(nvm current)" = "_v0.6.21" ] || die "v0.6.21-pre not reported as v0.6.21, got $(nvm current)"
 

--- a/test/slow/nvm use/Running "nvm use iojs" uses latest io.js version
+++ b/test/slow/nvm use/Running "nvm use iojs" uses latest io.js version
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+nvm deactivate 2>&1 >/dev/null || die 'deactivate failed'
+
+nvm use iojs || die 'nvm use iojs failed'
+OUTPUT="$(nvm current)"
+EXPECTED_OUTPUT="iojs-v1.0.1"
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "'nvm use iojs' + 'nvm current' did not output '$EXPECTED_OUTPUT'; got '$OUTPUT'"

--- a/test/slow/nvm use/Running "nvm use node" uses latest stable node version
+++ b/test/slow/nvm use/Running "nvm use node" uses latest stable node version
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+nvm deactivate 2>&1 >/dev/null || die 'deactivate failed'
+
+nvm use node || die 'nvm use node failed'
+OUTPUT="$(nvm current)"
+EXPECTED_OUTPUT="$(nvm_version stable)"
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "'nvm use node' + 'nvm current' did not output '$EXPECTED_OUTPUT'; got '$OUTPUT'"

--- a/test/slow/nvm use/setup_dir
+++ b/test/slow/nvm use/setup_dir
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+. ../../../nvm.sh
+
+mkdir -p ../../../.nvm_use_bak
+if [ -d "../../../v*" ]; then
+  mv "../../../v*" ../../../.nvm_use_bak/
+fi
+
+for VERSION in "0.8.7" "0.9.1" "0.10.1" "0.11.1"; do
+  nvm install "v$VERSION"
+done
+
+for VERSION in "1.0.0" "1.0.1"; do
+  nvm install "iojs-v$VERSION"
+done

--- a/test/slow/nvm use/teardown_dir
+++ b/test/slow/nvm use/teardown_dir
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+. ../../../nvm.sh
+
+for VERSION in "0.8.7" "0.9.1" "0.10.1" "0.11.1"; do
+  nvm uninstall "$VERSION"
+done
+
+for VERSION in "1.0.0" "1.0.1"; do
+  nvm uninstall "iojs-v$VERSION"
+done
+
+if [ -d ../../../.nvm_use_bak/* ]; then
+  mv ../../../.nvm_use_bak/* ../../../
+fi
+rmdir ../../../.nvm_use_bak


### PR DESCRIPTION
This branch adds support for https://github.com/iojs/io.js / https://iojs.org/

The following features should now work:
 - `nvm install iojs` will install the latest `io.js` version. `nvm ls iojs` and `nvm use iojs` will function as you'd expect.
 - `nvm install node` will install the latest stable `node` version. `nvm ls node` and `nvm use node` will function as you'd expect.
 - In general, a specific `io.js` version can be referenced with the "iojs-" prefix. If `node` were to ever release a `v1.0.0`, `v1.0.0` would refer to `node`, and `iojs-v1.0.0` would refer to `io.js`. In the near future, `node-v1.0.0` will also refer to `node` unambiguously. This applies to all `nvm` commands, including working with aliases and `.nvmrc` files.
 - `io.js`, unlike `node`, does not have a SunOS binary. Please open an issue on https://github.com/iojs/io.js if this is actually a problem for anyone, as currently it seems like this won't be for anybody.

**Note**: checksum support upon installation is currently disabled. Relates to https://github.com/iojs/io.js/issues/368.
**Note**: installation of `io.js` directly from source (via the `-s` option) is not yet enabled. This will be added soon.

Relates to https://github.com/iojs/io.js/issues/40 https://github.com/iojs/io.js/issues/420
Fixes #590

I'm going to merge and release this after a number of people test this on their own machines - hopefully sometime on the 19th.

Constructive feedback about this feature, or its usage, is welcome. Please keep "+1"'s and comments that add no value to a minimum.