### PR TITLE
Update "nvm use" to also alter npm's "prefix" configuration value

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -53,6 +53,10 @@ nvm_has_system_iojs() {
   [ "$(nvm deactivate >/dev/null 2>&1 && command -v iojs)" != '' ]
 }
 
+get_npm_global_prefix() {
+	echo $(cd $(dirname $(which node))/../ && pwd)
+}
+
 # Make zsh glob matching behave same as bash
 # This fixes the "zsh: no matches found" errors
 if nvm_has "unsetopt"; then
@@ -1271,11 +1275,18 @@ nvm() {
         return 127
       fi
 
+	  local NPM_GLOBAL_PREFIX
       if [ "_$VERSION" = '_system' ]; then
         if nvm_has_system_node && nvm deactivate >/dev/null 2>&1; then
+	      NPM_GLOBAL_PREFIX=$(get_npm_global_prefix)
+		  echo Updating npm global "prefix" to ${NPM_GLOBAL_PREFIX}
+		  npm config set prefix ${NPM_GLOBAL_PREFIX}
           echo "Now using system version of node: $(node -v 2>/dev/null)."
           return
         elif nvm_has_system_iojs && nvm deactivate >/dev/null 2>&1; then
+	      NPM_GLOBAL_PREFIX=$(get_npm_global_prefix)
+		  echo Updating npm global "prefix" to ${NPM_GLOBAL_PREFIX}
+		  npm config set prefix ${NPM_GLOBAL_PREFIX}
           echo "Now using system version of io.js: $(iojs --version 2>/dev/null)."
           return
         else
@@ -1319,6 +1330,9 @@ nvm() {
       else
         echo "Now using node $VERSION"
       fi
+	  NPM_GLOBAL_PREFIX=$(get_npm_global_prefix)
+	  echo Updating npm global "prefix" to ${NPM_GLOBAL_PREFIX}
+	  npm config set prefix ${NPM_GLOBAL_PREFIX}
     ;;
     "run" )
       local provided_version


### PR DESCRIPTION
My project makes use of libraries that have what I like to call "special C bits" -- specifically "[zmq](https://github.com/JustinTulloss/zeromq.node)" and "[mongodb](https://github.com/mongodb/node-mongodb-native)" -- which require compilation per version of node. In order to test one module that depends on _zmq_ with multiple node / iojs versions, you'd have to either recompile the _zmq_ library each time you ran the "nvm use" command, OR write a script to install certain libraries (like _zmq_) in separate, version specific global npm prefix directories.

The changes in this pull request would simply run the "npm config set prefix" command to change npm's "prefix" variable to be something other than the default of _/usr_ or _/usr/local_

If it's the case that this is too special casey, please let me know, and consider adding a flag to the "nvm use" command. I'd much rather work from the mainline than my fork.

Also, I did read the [CONTRIBUTING](https://github.com/creationix/nvm/blob/master/CONTRIBUTING.md) page, but I'm not 100% sure on the most appropriate way to test it. What's required at a minimum is that 

 1. At least two node / iojs versions are installed, including "system"
 1. Switching between them updates the value returned by the `npm config get prefix` command.

Is it OK i.e best practice to install two arbitrary versions and switch between them? Should I go the extra mile to  install versions that aren't installed and remove them afterwards?

Thanks in advance.