### PR TITLE
nvm: support SHA256 instead of SHA1

### DIFF
--- a/test/fast/Unit tests/nvm_checksum_256
+++ b/test/fast/Unit tests/nvm_checksum_256
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+cleanup () {
+  rm tmp/emptyfile256 tmp/testfile256
+  rmdir tmp
+}
+die () { echo $@ ; cleanup; exit 1; }
+
+. ../../../nvm.sh
+
+mkdir -p tmp
+touch tmp/emptyfile256
+echo -n "test" > tmp/testfile256
+
+nvm_checksum_256 tmp/emptyfile256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" || die "nvm_checksum_256 on an empty file did not match the SHA256 digest of the empty string"
+nvm_checksum_256 tmp/testfile256 "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08" && echo $_$NVM_CHECKSUM_256 && die "nvm_checksum_256 allowed a bad checksum"
+
+cleanup


### PR DESCRIPTION
Supports iojs and Node SHA256 checksumming instead of SHA1 for Node and nothing for ` iojs `. Should support at least Ubuntu, Debian, Linux Mint, Arch Linux, Gentoo, OpenBSD, FreeBSD, CentOS, OS X and Cygwin.

There's a whole range of fallbacks there, from the regular shasums to BSD & OS X's more centralised one `shasum` which does everything and then has fallbacks on 4 of the more popular/new/shiny SSL tools in PolarSSL, OpenSSL, LibreSSL and BoringSSL.

I know there were concerns about this sort of thing previously because of some systems lacking SHA256, but the introduction of the SSL Toolkits as backups should mitigate that quite a bit. I tested the OpenSSL branch way back to OpenSSL 0.9.8e and found that to support the method used here. OpenBSD is trying to kill off OpenSSL on their system slowly, so LibreSSL as well as the ` shasum ` BSD utility should cover those.