### PR TITLE
fix: download url for iojs armv6l and armv7l. #678 #227

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -859,7 +859,6 @@ nvm_get_arch() {
   case "$NVM_UNAME" in
     *x86_64*) NVM_ARCH=x64 ;;
     *i*86*) NVM_ARCH=x86 ;;
-    *armv6l*) NVM_ARCH=arm-pi ;;
     *) NVM_ARCH="$(uname -m)" ;;
   esac
   echo "$NVM_ARCH"

--- a/nvm.sh
+++ b/nvm.sh
@@ -938,10 +938,10 @@ nvm_install_node_binary() {
     if nvm_binary_available "$VERSION"; then
       local NVM_ARCH
       NVM_ARCH="$(nvm_get_arch)"
-      if [ $NVM_ARCH == "armv6l" ]; then
+      if [ $NVM_ARCH = "armv6l" ]; then
          NVM_ARCH="arm-pi"
       fi
-      t="$VERSION-$NVM_OS-$nvm_arch"
+      t="$VERSION-$NVM_OS-$NVM_ARCH"
       url="$NVM_NODEJS_ORG_MIRROR/$VERSION/node-${t}.tar.gz"
       sum=`nvm_download -L -s $NVM_NODEJS_ORG_MIRROR/$VERSION/SHASUMS.txt -o - | command grep node-${t}.tar.gz | command awk '{print $1}'`
       local tmpdir

--- a/nvm.sh
+++ b/nvm.sh
@@ -936,7 +936,8 @@ nvm_install_node_binary() {
 
   if [ -n "$NVM_OS" ]; then
     if nvm_binary_available "$VERSION"; then
-      nvm_arch="$(nvm_get_arch)"
+      local NVM_ARCH
+      NVM_ARCH="$(nvm_get_arch)"
       if [ $nvm_arch = "armv6l" ]; then
          nvm_arch="arm-pi"
       fi

--- a/nvm.sh
+++ b/nvm.sh
@@ -936,7 +936,11 @@ nvm_install_node_binary() {
 
   if [ -n "$NVM_OS" ]; then
     if nvm_binary_available "$VERSION"; then
-      t="$VERSION-$NVM_OS-$(nvm_get_arch)"
+      nvm_arch="$(nvm_get_arch)"
+      if [ $nvm_arch = "armv6l" ]; then
+         nvm_arch="arm-pi"
+      fi
+      t="$VERSION-$NVM_OS-$nvm_arch"
       url="$NVM_NODEJS_ORG_MIRROR/$VERSION/node-${t}.tar.gz"
       sum=`nvm_download -L -s $NVM_NODEJS_ORG_MIRROR/$VERSION/SHASUMS.txt -o - | command grep node-${t}.tar.gz | command awk '{print $1}'`
       local tmpdir

--- a/nvm.sh
+++ b/nvm.sh
@@ -938,8 +938,8 @@ nvm_install_node_binary() {
     if nvm_binary_available "$VERSION"; then
       local NVM_ARCH
       NVM_ARCH="$(nvm_get_arch)"
-      if [ $nvm_arch = "armv6l" ]; then
-         nvm_arch="arm-pi"
+      if [ $NVM_ARCH == "armv6l" ]; then
+         NVM_ARCH="arm-pi"
       fi
       t="$VERSION-$NVM_OS-$nvm_arch"
       url="$NVM_NODEJS_ORG_MIRROR/$VERSION/node-${t}.tar.gz"


### PR DESCRIPTION
Fixed the download url for raspberry pi related `armv6l` and `armv7l` for iojs. I could only test for `armv6l` as I don't have a Raspberry PI 2, but the the url should be correct for [iojs v1.3.0](https://iojs.org/dist/v1.3.0/) and below. 

The latest iojs version don't have the build the `armv6l`, but i'm guessing it's in progress. I think we can check with @rvagg on whether `armv6l` builds will be available for future versions of iojs.

Thanks :smile: 