### PR TITLE
- fixed return code of 1 when updating from git

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,10 @@ install_nvm_from_git() {
     mkdir -p "$NVM_DIR"
     command git clone "$(nvm_source git)" "$NVM_DIR"
   fi
-  cd "$NVM_DIR" && command git checkout --quiet $(nvm_latest_version) && command git branch --quiet -D master >/dev/null 2>&1
+  cd "$NVM_DIR" && command git checkout --quiet $(nvm_latest_version)
+  if [ ! -z "$(cd "$NVM_DIR" && git show-ref refs/heads/master)" ]; then
+    cd "$NVM_DIR" && command git branch --quiet -D master >/dev/null 2>&1
+  fi
   return
 }
 


### PR DESCRIPTION
When used with a privisioning system that monitors exit status, updating from git fails on line 72:
`cd "$NVM_DIR" && command git checkout --quiet $(nvm_latest_version) && command git branch --quiet -D master >/dev/null 2>&1`

This is because `master` doesn't exist.

This patch checks for the existance of `master` before deleting the branch.