### PR TITLE
Fix error message when sourcing nvm.sh

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1697,7 +1697,7 @@ $NVM_LS_REMOTE_IOJS_OUTPUT" | command grep -v "N/A" | sed '/^$/d')"
 }
 
 nvm_supports_source_options() {
-  [ "_$(echo 'echo $1' | . /dev/stdin yes)" = "_yes" ]
+  [ "_$(echo 'echo $1' | . /dev/stdin yes 2> /dev/null)" = "_yes" ]
 }
 
 if nvm_supports_source_options && [ "_$1" = "_--install" ]; then


### PR DESCRIPTION
Sourcing `nvm.sh` in version `0.24.0` results in the following message being output to stderr:

    ls: yes: No such file or directory

This is caused by `nvm_supports_source_options`, which fails (as it should apparently) in my environment. While the failing is expected, the error message doesn't seem so, and I personally find it a bit nagging to always see that message when starting a new shell session.

The fix in this PR is very simple, and it doesn't seem to break any test.