### PR TITLE
source command also necessary following the install script step

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,10 @@ or Wget:
 
     wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.24.0/install.sh | bash
 
+To activate nvm, you need to source it from your shell:
+
+    source ~/.nvm/nvm.sh
+
 <sub>The script clones the nvm repository to `~/.nvm` and adds the source line to your profile (`~/.bash_profile`, `~/.zshrc` or `~/.profile`).</sub>
 
 You can customize the install source, directory and profile using the `NVM_SOURCE`, `NVM_DIR`, and `PROFILE` variables.


### PR DESCRIPTION
here is the Stackoverflow quesiton: http://stackoverflow.com/questions/16904658/node-version-manager-install-nvm-command-not-found/17707224#17707224

seems that this is a common problem. I installed via curl but still i had to do the source comand to get the nvm running.