### PR TITLE
Support for nodejs release candidates

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -651,7 +651,7 @@ nvm_ls_remote() {
     PATTERN=".*"
   fi
   VERSIONS=`nvm_download -L -s $NVM_NODEJS_ORG_MIRROR/ -o - \
-              | \egrep -o 'v[0-9]+\.[0-9]+\.[0-9]+' \
+              | \egrep -o 'v[0-9]+\.[0-9]+\.[0-9]+(-rc\d+)?' \
               | command grep -w "${PATTERN}" \
               | sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n`
   if [ -z "$VERSIONS" ]; then


### PR DESCRIPTION
See https://github.com/joyent/node/pull/14412 for more details on a
proposal to include release candidates in Node.js' release process.

The goal of this PR is first to get some initial feedback on:
1. Having release candidates done during Node.js' release process.
2. The actual change, and the nomenclature that has currently been chosen for these release candidates releases (the `(-rc\d+)?` addition to the ls-remote regexp).

This change has been tested with a "fake" release candidate of Node.js available here: https://nodejs.org/dist/v0.12.3-rc1/.