### PR TITLE
Include npm version when displaying results of switch.

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1360,10 +1360,10 @@ nvm() {
 
       if [ "_$VERSION" = '_system' ]; then
         if nvm_has_system_node && nvm deactivate >/dev/null 2>&1; then
-          echo "Now using system version of node: $(node -v 2>/dev/null)."
+          echo "Now using system version of node: $(node -v 2>/dev/null) (npm v$(npm --version 2>/dev/null))"
           return
         elif nvm_has_system_iojs && nvm deactivate >/dev/null 2>&1; then
-          echo "Now using system version of io.js: $(iojs --version 2>/dev/null)."
+          echo "Now using system version of io.js: $(iojs --version 2>/dev/null) (npm v$(npm --version 2>/dev/null))"
           return
         else
           echo "System version of node not found." >&2
@@ -1407,10 +1407,11 @@ nvm() {
         command rm -f "$NVM_DIR/current" && ln -s "$NVM_VERSION_DIR" "$NVM_DIR/current"
       fi
       if nvm_is_iojs_version "$VERSION"; then
-        echo "Now using io.js $(nvm_strip_iojs_prefix "$VERSION")"
+        echo -n "Now using io.js $(nvm_strip_iojs_prefix "$VERSION")"
       else
-        echo "Now using node $VERSION"
+        echo -n "Now using node $VERSION"
       fi
+      echo " (npm v$(npm --version 2>/dev/null))"
     ;;
     "run" )
       local provided_version

--- a/nvm.sh
+++ b/nvm.sh
@@ -1359,11 +1359,13 @@ nvm() {
       fi
 
       if [ "_$VERSION" = '_system' ]; then
+        local NPM_VERSION
+        NPM_VERSION="(npm v$(npm --version 2>/dev/null))"
         if nvm_has_system_node && nvm deactivate >/dev/null 2>&1; then
-          echo "Now using system version of node: $(node -v 2>/dev/null) (npm v$(npm --version 2>/dev/null))"
+          echo "Now using system version of node: $(node -v 2>/dev/null) $NPM_VERSION"
           return
         elif nvm_has_system_iojs && nvm deactivate >/dev/null 2>&1; then
-          echo "Now using system version of io.js: $(iojs --version 2>/dev/null) (npm v$(npm --version 2>/dev/null))"
+          echo "Now using system version of io.js: $(iojs --version 2>/dev/null) $NPM_VERSION"
           return
         else
           echo "System version of node not found." >&2
@@ -1406,12 +1408,13 @@ nvm() {
       if [ "$NVM_SYMLINK_CURRENT" = true ]; then
         command rm -f "$NVM_DIR/current" && ln -s "$NVM_VERSION_DIR" "$NVM_DIR/current"
       fi
+      local NPM_VERSION
+      NPM_VERSION="(npm v$(npm --version 2>/dev/null))"
       if nvm_is_iojs_version "$VERSION"; then
-        echo -n "Now using io.js $(nvm_strip_iojs_prefix "$VERSION")"
+        echo "Now using io.js $(nvm_strip_iojs_prefix "$VERSION") $NPM_VERSION"
       else
-        echo -n "Now using node $VERSION"
+        echo "Now using node $VERSION $NPM_VERSION"
       fi
-      echo " (npm v$(npm --version 2>/dev/null))"
     ;;
     "run" )
       local provided_version

--- a/nvm.sh
+++ b/nvm.sh
@@ -1360,7 +1360,9 @@ nvm() {
 
       if [ "_$VERSION" = '_system' ]; then
         local NPM_VERSION
-        NPM_VERSION="(npm v$(npm --version 2>/dev/null))"
+        if nvm_has "npm"; then
+            NPM_VERSION="(npm v$(npm --version 2>/dev/null))"
+        fi
         if nvm_has_system_node && nvm deactivate >/dev/null 2>&1; then
           echo "Now using system version of node: $(node -v 2>/dev/null) $NPM_VERSION"
           return
@@ -1409,7 +1411,9 @@ nvm() {
         command rm -f "$NVM_DIR/current" && ln -s "$NVM_VERSION_DIR" "$NVM_DIR/current"
       fi
       local NPM_VERSION
-      NPM_VERSION="(npm v$(npm --version 2>/dev/null))"
+      if nvm_has "npm"; then
+        NPM_VERSION="(npm v$(npm --version 2>/dev/null))"
+      fi
       if nvm_is_iojs_version "$VERSION"; then
         echo "Now using io.js $(nvm_strip_iojs_prefix "$VERSION") $NPM_VERSION"
       else

--- a/test/fast/Running "nvm use system" should work as expected
+++ b/test/fast/Running "nvm use system" should work as expected
@@ -5,7 +5,7 @@ die () { echo $@ ; exit 1; }
 . ../../nvm.sh
 
 nvm_has_system_node() { return 0; }
-[ "$(nvm use system 2>&1 | tail -n1)" = "Now using system version of node: $(node -v)." ] || die "Could not use system version of node"
+[ "$(nvm use system 2>&1 | tail -n1)" = "Now using system version of node: $(node -v) (npm v$(npm -v))" ] || die "Could not use system version of node"
 
 nvm_has_system_node() { return 1; }
 [ "$(nvm use system 2>&1 | tail -n1)" = "System version of node not found." ] || die "Did not report error, system node not found"


### PR DESCRIPTION
When running nvm use, successful changing of versions lists the new node version.  The npm version may also be switched, but this is not listed.

This commit updates nvm to display the npm version that was switched to alongside the node version