### PR TITLE
adding architecture detection for Raspberry Pi 2

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -973,7 +973,7 @@ nvm_install_node_binary() {
     if nvm_binary_available "$VERSION"; then
       local NVM_ARCH
       NVM_ARCH="$(nvm_get_arch)"
-      if [ $NVM_ARCH = "armv6l" ]; then
+      if [ $NVM_ARCH = "armv6l" ] || [ $NVM_ARCH = "armv7l" ]; then
          NVM_ARCH="arm-pi"
       fi
       t="$VERSION-$NVM_OS-$NVM_ARCH"


### PR DESCRIPTION
 I have no idea how to write tests for this. I have about 3hrs of linux/RPi experience, but I know that my Raspberry Pi 2 reports an architecture of armv7l whereas nvm currently only detects armv6l as a Raspberry Pi. I made this change on my machine and it worked, so I am contributing my changes. :-) Hopefully they help.

If you want to give me a little direction on how to write and run tests I can try to help out with that also. :-)