### PR TITLE
Detect shell type from $SHELL variable instead of .$SHELLrc files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,16 +117,38 @@ install_nvm_as_script() {
 # Otherwise, an empty string is returned
 #
 nvm_detect_profile() {
-  if [ -f "$PROFILE" ]; then
-    echo "$PROFILE"
-  elif [ -f "$HOME/.bashrc" ]; then
-    echo "$HOME/.bashrc"
-  elif [ -f "$HOME/.bash_profile" ]; then
-    echo "$HOME/.bash_profile"
-  elif [ -f "$HOME/.zshrc" ]; then
-    echo "$HOME/.zshrc"
-  elif [ -f "$HOME/.profile" ]; then
-    echo "$HOME/.profile"
+
+  local DETECTED_PROFILE
+  DETECTED_PROFILE=''
+  local SHELLTYPE
+  SHELLTYPE="$(basename /$SHELL)"
+
+  if [ $SHELLTYPE = "bash" ]; then
+    if [ -f "$HOME/.bashrc" ]; then
+      DETECTED_PROFILE="$HOME/.bashrc"
+    elif [ -f "$HOME/.bash_profile" ]; then
+      DETECTED_PROFILE="$HOME/.bash_profile"
+    fi
+  elif [ $SHELLTYPE = "zsh" ]; then
+    DETECTED_PROFILE="$HOME/.zshrc"
+  fi
+
+  if [ -z $DETECTED_PROFILE ]; then
+    if [ -f "$PROFILE" ]; then
+      DETECTED_PROFILE="$PROFILE"
+    elif [ -f "$HOME/.profile" ]; then
+      DETECTED_PROFILE="$HOME/.profile"
+    elif [ -f "$HOME/.bashrc" ]; then
+      DETECTED_PROFILE="$HOME/.bashrc"
+    elif [ -f "$HOME/.bash_profile" ]; then
+      DETECTED_PROFILE="$HOME/.bash_profile"
+    elif [ -f "$HOME/.zshrc" ]; then
+      DETECTED_PROFILE="$HOME/.zshrc"
+    fi
+  fi
+
+  if [ ! -z $DETECTED_PROFILE ]; then
+    echo "$DETECTED_PROFILE"
   fi
 }
 

--- a/test/install_script/nvm_detect_profile
+++ b/test/install_script/nvm_detect_profile
@@ -22,46 +22,80 @@ HOME="."
 
 setup
 
+#Let's force $SHELL to be bash
+SHELL="/bin/bash"
+
+# $SHELL is set to bash and .bashrc is there, it must be detected
+_PROFILE=$(nvm_detect_profile)
+[ "_$_PROFILE" = "_$HOME/.bashrc" ] || echo "_\$HOME/.bashrc: _$HOME/.bashrc\n" \
+                                       echo "_\$_PROFILE: _$_PROFILE\n" \
+                                       die "nvm_detect_profile didn't pick $SHELL and $HOME/.bashrc"
+
+#Let's force $SHELL to be zsh
+SHELL="/usr/bin/zsh"
+
+# $SHELL is set to zsh and .zshrc is there, it must be detected
+_PROFILE=$(nvm_detect_profile)
+[ "_$_PROFILE" = "_$HOME/.zshrc" ] || echo "_\$HOME/.zshrc: _$HOME/.zshrc\n" \
+                                      echo "_\$_PROFILE: _$_PROFILE\n" \
+                                      die "nvm_detect_profile didn't pick $SHELL and $HOME/.zshrc"
+
+
+# if we unset shell it looks for the files
+unset SHELL
 
 # $PROFILE points to a valid file, its path must be returned
 PROFILE="test_profile"
 _PROFILE=$(nvm_detect_profile)
-[ "_$_PROFILE" = "_$PROFILE" ] || die "nvm_detect_profile didn't pick \$PROFILE"
+[ "_$_PROFILE" = "_$PROFILE" ] || echo "_\$_PROFILE: _$_PROFILE\n" \
+                                  echo "_\$PROFILE: _$PROFILE\n" \
+                                  die "nvm_detect_profile didn't pick \$PROFILE"
 
 # $PROFILE doesn't point to a valid file, its path must not be returned
 PROFILE="invalid_profile"
 _PROFILE=$(nvm_detect_profile)
-[ "_$_PROFILE" != "_$PROFILE" ] || die "nvm_detect_profile shouldn't pick \$PROFILE when it's not a valid file"
+[ "_$_PROFILE" != "_$PROFILE" ] || echo "_\$_PROFILE: _$_PROFILE\n" \
+                                   echo "_\$PROFILE: _$PROFILE\n" \
+                                   die "nvm_detect_profile shouldn't pick \$PROFILE when it's not a valid file"
 
 
 # Below are tests for when $PROFILE is undefined
 rm test_profile
 unset PROFILE
 
-# It should favor .bashrc if file exists
+# It should favor .profile if file exists
 _PROFILE=$(nvm_detect_profile)
-[ "_$_PROFILE" = "_$HOME/.bashrc" ] || die "nvm_detect_profile should have selected .bashrc"
+[ "_$_PROFILE" = "_$HOME/.profile" ] || echo "_\$_PROFILE: _$_PROFILE\n" \
+                                        echo "_\$PROFILE: _$PROFILE\n" \
+                                        die "nvm_detect_profile should have selected .profile"
+
+rm .profile
+# Otherwise, it should favor .bashrc if file exists
+_PROFILE=$(nvm_detect_profile)
+[ "_$_PROFILE" = "_$HOME/.bashrc" ] || echo "_\$_PROFILE: _$_PROFILE\n" \
+                                       echo "_\$PROFILE: _$PROFILE\n" \
+                                       die "nvm_detect_profile should have selected .bashrc"
 
 rm .bashrc
 # Otherwise, it should favor .bash_profile if file exists
 _PROFILE=$(nvm_detect_profile)
-[ "_$_PROFILE" = "_$HOME/.bash_profile" ] || die "nvm_detect_profile should have selected .bash_profile"
+[ "_$_PROFILE" = "_$HOME/.bash_profile" ] || echo "_\$_PROFILE: _$_PROFILE\n" \
+                                             echo "_\$PROFILE: _$PROFILE\n" \
+                                             die "nvm_detect_profile should have selected .bash_profile"
 
 rm .bash_profile
 # Otherwise, it should favor .zshrc if file exists
 _PROFILE=$(nvm_detect_profile)
-[ "_$_PROFILE" = "_$HOME/.zshrc" ] || die "nvm_detect_profile should have selected .zshrc"
+[ "_$_PROFILE" = "_$HOME/.zshrc" ] || echo "_\$_PROFILE: _$_PROFILE\n" \
+                                      echo "_\$PROFILE: _$PROFILE\n" \
+                                      die "nvm_detect_profile should have selected .zshrc"
 
 rm .zshrc
-# Otherwise, it should favor .profile if file exists
-_PROFILE=$(nvm_detect_profile)
-[ "_$_PROFILE" = "_$HOME/.profile" ] || die "nvm_detect_profile should have selected .profile"
-
-rm .profile
 # It should be empty if none is found
 _PROFILE=$(nvm_detect_profile)
-[ -z "$_PROFILE" ] || die "nvm_detect_profile should have echo'ed an empty value"
+[ -z "$_PROFILE" ] || echo "_\$_PROFILE: _$_PROFILE\n" \
+                      echo "_\$PROFILE: _$PROFILE\n" \
+                      die "nvm_detect_profile should have echo'ed an empty value"
 
 
 cleanup
-


### PR DESCRIPTION
As per commit message.
I am using zsh on Ubuntu, but I am keeping also the default `.bashrc` that gets shipped with Ubuntu in my home folder. As of now, the nvm "loading" configuration gets added to `$HOME/.bashrc` because the check on `.bashrc` is encountered before the check on `.zshrc`.

`basename` is part of the GNU coreutils so it should be widely available and this should work also on other OSes.

## Testing the various shells
(`sh` is `dash` on my system)

### Launch from zsh
```
[~/extra/nvm/nvm]$ cat ./install.sh | sh
=> Downloading nvm from git to '/home/cristian/.nvm'
=> Cloning into '/home/cristian/.nvm'...
remote: Counting objects: 3693, done.
remote: Total 3693 (delta 0), reused 0 (delta 0), pack-reused 3693
Receiving objects: 100% (3693/3693), 827.00 KiB | 0 bytes/s, done.
Resolving deltas: 100% (2132/2132), done.
Checking connectivity... done.
* (detached from v0.25.4)

=> Appending source string to /home/cristian/.zshrc
=> Close and reopen your terminal to start using nvm
```

### Launch from bash
```
$ bash
cristian@wash:~/extra/nvm/nvm$ cat ./install.sh | sh
=> Downloading nvm from git to '/home/cristian/.nvm'
=> Cloning into '/home/cristian/.nvm'...
remote: Counting objects: 3693, done.
remote: Total 3693 (delta 0), reused 0 (delta 0), pack-reused 3693
Receiving objects: 100% (3693/3693), 827.00 KiB | 0 bytes/s, done.
Resolving deltas: 100% (2132/2132), done.
Checking connectivity... done.
* (detached from v0.25.4)

=> Source string already in /home/cristian/.zshrc
=> Close and reopen your terminal to start using nvm
```

### Launch from ksh
```
$ ksh
$ cat ./install.sh | sh
=> Downloading nvm from git to '/home/cristian/.nvm'
=> Cloning into '/home/cristian/.nvm'...
remote: Counting objects: 3693, done.
remote: Total 3693 (delta 0), reused 0 (delta 0), pack-reused 3693
Receiving objects: 100% (3693/3693), 827.00 KiB | 1.41 MiB/s, done.
Resolving deltas: 100% (2132/2132), done.
Checking connectivity... done.
* (detached from v0.25.4)

=> Source string already in /home/cristian/.zshrc
=> Close and reopen your terminal to start using nvm
```

### Launch from sh
```
$ sh
$ cat ./install.sh | sh
=> Downloading nvm from git to '/home/cristian/.nvm'
=> Cloning into '/home/cristian/.nvm'...
remote: Counting objects: 3693, done.
remote: Total 3693 (delta 0), reused 0 (delta 0), pack-reused 3693
Receiving objects: 100% (3693/3693), 827.00 KiB | 0 bytes/s, done.
Resolving deltas: 100% (2132/2132), done.
Checking connectivity... done.
* (detached from v0.25.4)
  master

=> Source string already in /home/cristian/.zshrc
=> Close and reopen your terminal to start using nvm
```

