### PR TITLE
Add --without-snapshot configure flag to ARM devices by default

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1022,6 +1022,12 @@ nvm_install_node_source() {
   local ADDITIONAL_PARAMETERS
   ADDITIONAL_PARAMETERS="$2"
 
+  local NVM_ARCH
+  NVM_ARCH="$(nvm_get_arch)"
+  if [[ $NVM_ARCH = *"arm"* ]]; then
+    ADDITIONAL_PARAMETERS+=" --without-snapshot"
+  fi
+
   if [ -n "$ADDITIONAL_PARAMETERS" ]; then
     echo "Additional options while compiling: $ADDITIONAL_PARAMETERS"
   fi

--- a/nvm.sh
+++ b/nvm.sh
@@ -1024,8 +1024,8 @@ nvm_install_node_source() {
 
   local NVM_ARCH
   NVM_ARCH="$(nvm_get_arch)"
-  if [[ $NVM_ARCH = *"arm"* ]]; then
-    ADDITIONAL_PARAMETERS+=" --without-snapshot"
+  if [ $NVM_ARCH = "armv6l" ] || [ $NVM_ARCH = "armv7l" ]; then
+    ADDITIONAL_PARAMETERS="--without-snapshot $ADDITIONAL_PARAMETERS"
   fi
 
   if [ -n "$ADDITIONAL_PARAMETERS" ]; then

--- a/test/installation/node/install from source without V8 snapshot for ARM
+++ b/test/installation/node/install from source without V8 snapshot for ARM
@@ -17,9 +17,6 @@ nvm_get_arch() {
 # Install from source
 nvm install -s $NVM_TEST_VERSION || die "'nvm install -s $NVM_TEST_VERSION' failed"
 
-# Use new version
-nvm use $NVM_TEST_VERSION
-
 # Check Install
 [ -d ../../../$NVM_TEST_VERSION ]
 node --version | grep $NVM_TEST_VERSION || "'node --version | grep $NVM_TEST_VERSION' failed"

--- a/test/installation/node/install from source without V8 snapshot for ARM
+++ b/test/installation/node/install from source without V8 snapshot for ARM
@@ -17,10 +17,12 @@ nvm_get_arch() {
 # Install from source
 nvm install -s $NVM_TEST_VERSION || die "'nvm install -s $NVM_TEST_VERSION' failed"
 
+# Use new version
+nvm use $NVM_TEST_VERSION
+
 # Check Install
 [ -d ../../../$NVM_TEST_VERSION ]
-nvm run $NVM_TEST_VERSION --version | grep $NVM_TEST_VERSION || "'nvm run $NVM_TEST_VERSION --version | grep $NVM_TEST_VERSION' failed"
+node --version | grep $NVM_TEST_VERSION || "'node --version | grep $NVM_TEST_VERSION' failed"
 
 # Check V8 snapshot isn't compiled
-nvm run $NVM_TEST_VERSION -p process.config | grep "v8_use_snapshot: false" || "'nvm run $NVM_TEST_VERSION -p process.config | grep \"v8_use_snapshot: false\"' failed"
-
+node -p "if(! process.config.variables.v8_use_snapshot) { console.log('no-snapshot'); }" | grep "no-snapshot" || "'node -p \"if(! process.config.variables.v8_use_snapshot) { console.log('no-snapshot'); }\" | grep \"no-snapshot\"' failed"

--- a/test/installation/node/install from source without V8 snapshot for ARM
+++ b/test/installation/node/install from source without V8 snapshot for ARM
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+NVM_TEST_VERSION=v0.10.7
+
+# Remove the stuff we're clobbering.
+[ -e ../../../$NVM_TEST_VERSION ] && rm -R ../../../$NVM_TEST_VERSION
+
+# Fake ARM arch
+nvm_get_arch() {
+  echo "armv7l"
+}
+
+# Install from source
+nvm install -s $NVM_TEST_VERSION || die "'nvm install -s $NVM_TEST_VERSION' failed"
+
+# Check Install
+[ -d ../../../$NVM_TEST_VERSION ]
+nvm run $NVM_TEST_VERSION --version | grep $NVM_TEST_VERSION || "'nvm run $NVM_TEST_VERSION --version | grep $NVM_TEST_VERSION' failed"
+
+# Check V8 snapshot isn't compiled
+nvm run $NVM_TEST_VERSION -p process.config | grep "v8_use_snapshot: false" || "'nvm run $NVM_TEST_VERSION -p process.config | grep \"v8_use_snapshot: false\"' failed"

--- a/test/installation/node/install from source without V8 snapshot for ARM
+++ b/test/installation/node/install from source without V8 snapshot for ARM
@@ -23,3 +23,4 @@ nvm run $NVM_TEST_VERSION --version | grep $NVM_TEST_VERSION || "'nvm run $NVM_T
 
 # Check V8 snapshot isn't compiled
 nvm run $NVM_TEST_VERSION -p process.config | grep "v8_use_snapshot: false" || "'nvm run $NVM_TEST_VERSION -p process.config | grep \"v8_use_snapshot: false\"' failed"
+


### PR DESCRIPTION
At the time of this writing, there is a problem with the Google V8 Snapshot feature causing node to segmentation fault on ARM devices. Snapshotting helps node start faster and is not a big-deal feature so it's safe to disable by default for ARM.