### PR TITLE
Adding --silent option for nvm use, and using it to disable processing certain output to speed up shell startup

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1470,17 +1470,25 @@ nvm() {
 
       if [ "_$VERSION" = '_system' ]; then
         if nvm_has_system_node && nvm deactivate >/dev/null 2>&1; then
-          [ $silent -ne 1 ] && echo "Now using system version of node: $(node -v 2>/dev/null)$(nvm_print_npm_version)"
+          if [ $silent -ne 1 ]; then
+            echo "Now using system version of node: $(node -v 2>/dev/null)$(nvm_print_npm_version)"
+          fi
           return
         elif nvm_has_system_iojs && nvm deactivate >/dev/null 2>&1; then
-          [ $silent -ne 1 ] && echo "Now using system version of io.js: $(iojs --version 2>/dev/null)$(nvm_print_npm_version)"
+          if [ $silent -ne 1 ]; then
+            echo "Now using system version of io.js: $(iojs --version 2>/dev/null)$(nvm_print_npm_version)"
+          fi
           return
         else
-          [ $silent -ne 1 ] && echo "System version of node not found." >&2
+          if [ $silent -ne 1 ]; then
+            echo "System version of node not found." >&2
+          fi
           return 127
         fi
       elif [ "_$VERSION" = "_∞" ]; then
-        [ $silent -ne 1 ] && echo "The alias \"$PROVIDED_VERSION\" leads to an infinite loop. Aborting." >&2
+        if [ $silent -ne 1 ]; then
+          echo "The alias \"$PROVIDED_VERSION\" leads to an infinite loop. Aborting." >&2
+        fi
         return 8
       fi
 
@@ -1517,9 +1525,13 @@ nvm() {
         command rm -f "$NVM_DIR/current" && ln -s "$NVM_VERSION_DIR" "$NVM_DIR/current"
       fi
       if nvm_is_iojs_version "$VERSION"; then
-        [ $silent -ne 1 ] && echo "Now using io.js $(nvm_strip_iojs_prefix "$VERSION")$(nvm_print_npm_version)"
+        if [ $silent -ne 1 ]; then
+          echo "Now using io.js $(nvm_strip_iojs_prefix "$VERSION")$(nvm_print_npm_version)"
+        fi
       else
-        [ $silent -ne 1 ] && echo "Now using node $VERSION$(nvm_print_npm_version)"
+        if [ $silent -ne 1 ]; then
+          echo "Now using node $VERSION$(nvm_print_npm_version)"
+        fi
       fi
     ;;
     "run" )

--- a/nvm.sh
+++ b/nvm.sh
@@ -1476,11 +1476,11 @@ nvm() {
           [ $silent -ne 1 ] && echo "Now using system version of io.js: $(iojs --version 2>/dev/null)$(nvm_print_npm_version)"
           return
         else
-          echo "System version of node not found." >&2
+          [ $silent -ne 1 ] && echo "System version of node not found." >&2
           return 127
         fi
       elif [ "_$VERSION" = "_∞" ]; then
-        echo "The alias \"$PROVIDED_VERSION\" leads to an infinite loop. Aborting." >&2
+        [ $silent -ne 1 ] && echo "The alias \"$PROVIDED_VERSION\" leads to an infinite loop. Aborting." >&2
         return 8
       fi
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -61,7 +61,7 @@ nvm_has_system_iojs() {
 }
 
 nvm_print_npm_version() {
-  if nvm_has "npm"; then
+  if [ "$NVM_SILENT" != "true" ] && nvm_has "npm"; then
     echo " (npm v$(npm --version 2>/dev/null))"
   fi
 }
@@ -1882,7 +1882,9 @@ if nvm_supports_source_options && [ "_$1" = "_--install" ]; then
     nvm install >/dev/null
   fi
 elif [ -n "$VERSION" ]; then
+  NVM_SILENT="true"
   nvm use "$VERSION" >/dev/null
+  unset NVM_SILENT
 elif nvm_rc_version >/dev/null 2>&1; then
   nvm use >/dev/null
 fi

--- a/test/fast/Running "nvm use foo" where "foo" is circular aborts
+++ b/test/fast/Running "nvm use foo" where "foo" is circular aborts
@@ -18,5 +18,13 @@ EXPECTED_OUTPUT='The alias "foo" leads to an infinite loop. Aborting.'
 EXIT_CODE="$(nvm use foo 2>/dev/null ; echo $?)"
 [ "_$EXIT_CODE" = "_8" ] || die "Expected exit code 8; got $EXIT_CODE"
 
+OUTPUT="$(nvm use --silent foo 2>&1)"
+EXPECTED_OUTPUT=''
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "'nvm use --silent foo' did not output '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+
+EXIT_CODE="$(nvm use --silent foo 2>/dev/null ; echo $?)"
+[ "_$EXIT_CODE" = "_8" ] || die "Expected exit code 8 from 'nvm use --silent foo'; got $EXIT_CODE"
+
 cleanup;
 

--- a/test/fast/Running "nvm use iojs" uses latest io.js version
+++ b/test/fast/Running "nvm use iojs" uses latest io.js version
@@ -18,5 +18,13 @@ EXPECTED_OUTPUT='The alias "foo" leads to an infinite loop. Aborting.'
 EXIT_CODE="$(nvm use foo 2>/dev/null ; echo $?)"
 [ "_$EXIT_CODE" = "_8" ] || die "Expected exit code 8; got $EXIT_CODE"
 
+OUTPUT="$(nvm use --silent foo 2>&1)"
+EXPECTED_OUTPUT=''
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "'nvm use --silent foo' did not output '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+
+EXIT_CODE="$(nvm use --silent foo 2>/dev/null ; echo $?)"
+[ "_$EXIT_CODE" = "_8" ] || die "Expected exit code 8 from 'nvm use --silent foo'; got $EXIT_CODE"
+
 cleanup;
 

--- a/test/fast/Running "nvm use system" should work as expected
+++ b/test/fast/Running "nvm use system" should work as expected
@@ -8,10 +8,15 @@ nvm_has_system_node() { return 0; }
 nvm_print_npm_version() { return ' (npm v1.2.3)'; }
 EXPECTED_OUTPUT="Now using system version of node: $(node -v)$(nvm_print_npm_version)"
 [ "$(nvm use system 2>&1 | tail -n1)" = "$EXPECTED_OUTPUT" ] || die "Could not use system version of node"
+EXPECTED_OUTPUT=""
+[ "$(nvm use --silent system 2>&1 | tail -n1)" = "$EXPECTED_OUTPUT" ] || die "Could not use system version of node or --silent was not silent"
 
 nvm_has_system_node() { return 1; }
 nvm_print_npm_version() { return ''; }
 EXPECTED_OUTPUT="System version of node not found."
 [ "$(nvm use system 2>&1 | tail -n1)" = "$EXPECTED_OUTPUT" ] || die "Did not report error, system node not found"
 nvm use system 2>&1 > /dev/null || [ $? -eq 127 ] || die "Did not return error code, system node not found"
+EXPECTED_OUTPUT=""
+[ "$(nvm use --silent system 2>&1 | tail -n1)" = "$EXPECTED_OUTPUT" ] || die "Did not report error, system node not found or --silent was not silent"
+nvm use --silent system 2>&1 > /dev/null || [ $? -eq 127 ] || die "Did not return error code, system node not found or --silent was not silent"
 

--- a/test/slow/nvm use/Running "nvm use iojs" uses latest io.js version
+++ b/test/slow/nvm use/Running "nvm use iojs" uses latest io.js version
@@ -12,3 +12,9 @@ EXPECTED_OUTPUT="iojs-v1.0.1"
 
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
   || die "'nvm use iojs' + 'nvm current' did not output '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+
+OUTPUT="$(nvm use --silent iojs)"
+EXPECTED_OUTPUT=""
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "'nvm use --silent iojs' output was not silenced '$EXPECTED_OUTPUT'; got '$OUTPUT'"

--- a/test/slow/nvm use/Running "nvm use node" uses latest stable node version
+++ b/test/slow/nvm use/Running "nvm use node" uses latest stable node version
@@ -12,3 +12,9 @@ EXPECTED_OUTPUT="$(nvm_version stable)"
 
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
   || die "'nvm use node' + 'nvm current' did not output '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+
+OUTPUT="$(nvm use --silent node)"
+EXPECTED_OUTPUT=""
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "'nvm use --silent node' output was not silenced '$EXPECTED_OUTPUT'; got '$OUTPUT'"

--- a/test/slow/nvm use/Running "nvm use v1.0.0" uses iojs-v1.0.0 iojs version
+++ b/test/slow/nvm use/Running "nvm use v1.0.0" uses iojs-v1.0.0 iojs version
@@ -12,3 +12,9 @@ EXPECTED_OUTPUT="$(nvm_version v1.0.0)"
 
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
   || die "'nvm use v1.0.0' + 'nvm current' did not output '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+
+OUTPUT="$(nvm use --silent 'v1.0.0')"
+EXPECTED_OUTPUT=""
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "'nvm use --silent v1.0.0' output was not silenced '$EXPECTED_OUTPUT'; got '$OUTPUT'"


### PR DESCRIPTION
When sourcing nvm.sh, a considerable amount of time is spent running npm --version only for that output to be black-holed to /dev/null