### PR TITLE
Add usage string for --reinstall-packages-from

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1186,6 +1186,7 @@ nvm() {
       echo "  nvm help                              Show this message"
       echo "  nvm --version                         Print out the latest released version of nvm"
       echo "  nvm install [-s] <version>            Download and install a <version>, [-s] from source. Uses .nvmrc if available"
+      echo "    --reinstall-packages-from=<version> When installing, reinstall packages installed in <node|iojs|node version number>"
       echo "  nvm uninstall <version>               Uninstall a version"
       echo "  nvm use [--silent] <version>          Modify PATH to use <version>. Uses .nvmrc if available"
       echo "  nvm run <version> [<args>]            Run <version> with <args> as arguments. Uses .nvmrc if available for <version>"


### PR DESCRIPTION
@reybango added docs for this switch in the readme in #795. I attempted to add similar info in the `nvm help` usage output. Currently there's no clear format for documenting command switches in this help output (there's another, `--copy-packages-from` that I didn't add info for). If the style I used here is not acceptable that's fine, it can just be a starting point for discussion of how to doc some of these undocumented switches. :palm_tree: 