### PR TITLE
Replace links to nvm-fish and nvm-fish-wrapper with a link to bass

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,9 +8,8 @@ Note: `nvm` does not support Windows (see [#284](https://github.com/creationix/n
  - [nvmw](https://github.com/hakobera/nvmw)
  - [nvm-windows](https://github.com/coreybutler/nvm-windows)
 
-Note: `nvm` does not support [Fish] either (see [#303](https://github.com/creationix/nvm/issues/303)). Two alternatives exist, which are neither supported nor developed by us:
- - [nvm-fish-wrapper](https://github.com/passcod/nvm-fish-wrapper)
- - [nvm-fish](https://github.com/Alex7Kom/nvm-fish) (does not support iojs)
+Note: `nvm` does not support [Fish] either (see [#303](https://github.com/creationix/nvm/issues/303)). An alternative exists, which is neither supported nor developed by us:
+ - [bass](https://github.com/edc/bass) allows to use utilities written for Bash in fish shell
 
 ### Install script
 


### PR DESCRIPTION
Both are no longer maintained, both now link to [bass](https://github.com/edc/bass).