### PR TITLE
Support `xz` tarballs if available

### DIFF
--- a/test/fast/Unit tests/nvm_supports_xz
+++ b/test/fast/Unit tests/nvm_supports_xz
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+OLDPATH=$PATH
+TEST_PATH=../../xz-test
+
+mkdir $TEST_PATH
+touch ../../xz-test/xz
+chmod +x ../../xz-test/xz
+
+export PATH=$TEST_PATH:$PATH
+
+$(nvm_supports_xz "v2.3.2") || \
+  die "expected 'nvm_supports_xz v2.3.2' to exit with 0"
+
+$(nvm_supports_xz "v0.12.7") && \
+  die "expected 'nvm_supports_xz v0.12.7' to exit with 1"
+
+
+# set up for a failure by having a minimal toolset available
+# but remove xz
+ln -s /usr/bin/which $TEST_PATH/which
+ln -s /usr/bin/command $TEST_PATH/command
+ln -s /usr/bin/awk $TEST_PATH/awk
+ln -s $(which rm) $TEST_PATH/rm
+
+export PATH=$TEST_PATH
+rm $TEST_PATH/xz
+
+$(nvm_supports_xz "v2.3.2") && \
+  die "expected 'nvm_supports_xz v2.3.2' with a missing xz binary to exit with 1"
+
+export PATH=$OLDPATH

--- a/test/fast/teardown
+++ b/test/fast/teardown
@@ -6,5 +6,5 @@
 
   type setopt >/dev/null 2>&1 && setopt NULL_GLOB
   type shopt >/dev/null 2>&1 && shopt -s nullglob
-  rm -fR v* src alias
+  rm -fR v* src alias test/test-xz
 )


### PR DESCRIPTION
Saves us ~25% bandwidth, but only nodejs 4.0.0 and forward. We check for the existence of `xz` so older versions or targets without it is unaffected.