### PR TITLE
Clear environment variables when resourcing nvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ addons:
   - zsh
   - ksh
 install:
-  - (cd /usr/local/bin && wget https://raw.github.com/tlevine/urchin/master/urchin && chmod +x urchin)
+    - (cd /tmp && wget https://raw.github.com/tlevine/urchin/master/urchin && chmod +x urchin)
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
 script:
-  - urchin -f -s "$TEST_SHELL" "test/$TEST_SUITE"
+  - /tmp/urchin -f -s "$TEST_SHELL" "test/$TEST_SUITE"
 env:
   - TEST_SHELL=bash TEST_SUITE=install_script
   - TEST_SHELL=sh TEST_SUITE=fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - chmod +x /tmp/urchin/package/urchin
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
 script:
-  - NVM_DIR=$TRAVIS_BUILD_DIR make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin/package/urchin test-$SHELL
+  - make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin/package/urchin test-$SHELL
 env:
   - SHELL=bash TEST_SUITE=install_script
   - SHELL=sh TEST_SUITE=fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ addons:
   - zsh
   - ksh
 install:
-    - (cd /tmp && wget https://raw.github.com/tlevine/urchin/master/urchin && chmod +x urchin)
+  - (cd /tmp && wget https://raw.github.com/tlevine/urchin/master/urchin && chmod +x urchin)
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
 script:
   - /tmp/urchin -f -s "$TEST_SHELL" "test/$TEST_SUITE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,35 +4,34 @@ addons:
   - zsh
   - ksh
 install:
-  - (mkdir /tmp/urchin && cd /tmp/urchin && curl -s "$(curl -s https://registry.npmjs.com/urchin | grep -Eo '"tarball":\s*"[^"]+"' | tail -n 1 | awk -F\" '{ print $4 }')" -O && tar -x -f urchin*)
-  - chmod +x /tmp/urchin/package/urchin
+  - (cd /usr/local/bin && wget https://raw.github.com/tlevine/urchin/master/urchin && chmod +x urchin)
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
 script:
-  - make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin/package/urchin test-$SHELL
+  - urchin -f -s "$TEST_SHELL" "test/$TEST_SUITE"
 env:
-  - SHELL=bash TEST_SUITE=install_script
-  - SHELL=sh TEST_SUITE=fast
-  - SHELL=dash TEST_SUITE=fast
-  - SHELL=bash TEST_SUITE=fast
-  - SHELL=zsh TEST_SUITE=fast
-#  - SHELL=ksh TEST_SUITE=fast
-  - SHELL=sh TEST_SUITE=slow
-  - SHELL=dash TEST_SUITE=slow
-  - SHELL=bash TEST_SUITE=slow
-  - SHELL=zsh TEST_SUITE=slow
-#  - SHELL=ksh TEST_SUITE=slow
-  - SHELL=sh TEST_SUITE=sourcing
-  - SHELL=dash TEST_SUITE=sourcing
-  - SHELL=bash TEST_SUITE=sourcing
-  - SHELL=zsh TEST_SUITE=sourcing
-#  - SHELL=ksh TEST_SUITE=sourcing
-  - SHELL=sh TEST_SUITE=installation
-  - SHELL=sh TEST_SUITE=installation WITHOUT_CURL=1
-  - SHELL=dash TEST_SUITE=installation
-  - SHELL=dash TEST_SUITE=installation WITHOUT_CURL=1
-  - SHELL=bash TEST_SUITE=installation
-  - SHELL=bash TEST_SUITE=installation WITHOUT_CURL=1
-  - SHELL=zsh TEST_SUITE=installation
-  - SHELL=zsh TEST_SUITE=installation WITHOUT_CURL=1
-#  - SHELL=ksh TEST_SUITE=installation
-#  - SHELL=ksh TEST_SUITE=installation WITHOUT_CURL=1
+  - TEST_SHELL=bash TEST_SUITE=install_script
+  - TEST_SHELL=sh TEST_SUITE=fast
+  - TEST_SHELL=dash TEST_SUITE=fast
+  - TEST_SHELL=bash TEST_SUITE=fast
+  - TEST_SHELL=zsh TEST_SUITE=fast
+#  - TEST_SHELL=ksh TEST_SUITE=fast
+  - TEST_SHELL=sh TEST_SUITE=slow
+  - TEST_SHELL=dash TEST_SUITE=slow
+  - TEST_SHELL=bash TEST_SUITE=slow
+  - TEST_SHELL=zsh TEST_SUITE=slow
+#  - TEST_SHELL=ksh TEST_SUITE=slow
+  - TEST_SHELL=sh TEST_SUITE=sourcing
+  - TEST_SHELL=dash TEST_SUITE=sourcing
+  - TEST_SHELL=bash TEST_SUITE=sourcing
+  - TEST_SHELL=zsh TEST_SUITE=sourcing
+#  - TEST_SHELL=ksh TEST_SUITE=sourcing
+  - TEST_SHELL=sh TEST_SUITE=installation
+  - TEST_SHELL=sh TEST_SUITE=installation WITHOUT_CURL=1
+  - TEST_SHELL=dash TEST_SUITE=installation
+  - TEST_SHELL=dash TEST_SUITE=installation WITHOUT_CURL=1
+  - TEST_SHELL=bash TEST_SUITE=installation
+  - TEST_SHELL=bash TEST_SUITE=installation WITHOUT_CURL=1
+  - TEST_SHELL=zsh TEST_SUITE=installation
+  - TEST_SHELL=zsh TEST_SUITE=installation WITHOUT_CURL=1
+#  - TEST_SHELL=ksh TEST_SUITE=installation
+#  - TEST_SHELL=ksh TEST_SUITE=installation WITHOUT_CURL=1

--- a/nvm.sh
+++ b/nvm.sh
@@ -8,6 +8,14 @@
 
 { # this ensures the entire script is downloaded #
 
+unset NVM_DIR
+unset NVM_NODEJS_ORG_MIRROR
+unset NVM_IOJS_ORG_MIRROR
+unset NVM_RC_VERSION
+unset NODE_PATH
+unset NVM_PATH
+unset NVM_BIN
+
 NVM_SCRIPT_SOURCE="$_"
 
 nvm_has() {

--- a/nvm.sh
+++ b/nvm.sh
@@ -2096,7 +2096,8 @@ $NVM_LS_REMOTE_POST_MERGED_OUTPUT" | command grep -v "N/A" | command sed '/^$/d'
         nvm_has_system_node nvm_has_system_iojs \
         nvm_download nvm_get_latest nvm_has nvm_get_latest \
         nvm_supports_source_options > /dev/null 2>&1
-      unset RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_DIR NVM_CD_FLAGS > /dev/null 2>&1
+        unset NVM_RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR \
+          NVM_DIR NVM_CD_FLAGS NODE_PATH NVM_PATH NVM_BIN > /dev/null 2>&1
     ;;
     * )
       >&2 nvm help

--- a/nvm.sh
+++ b/nvm.sh
@@ -8,13 +8,10 @@
 
 { # this ensures the entire script is downloaded #
 
-unset NVM_DIR
-unset NVM_NODEJS_ORG_MIRROR
-unset NVM_IOJS_ORG_MIRROR
-unset NVM_RC_VERSION
-unset NODE_PATH
-unset NVM_PATH
-unset NVM_BIN
+# Unload any existing environment variables
+if type nvm | grep -i function > /dev/null; then
+   nvm unload
+fi
 
 NVM_SCRIPT_SOURCE="$_"
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -8,10 +8,36 @@
 
 { # this ensures the entire script is downloaded #
 
+nvm_unload() {
+  unset -f nvm nvm_print_versions nvm_checksum \
+    nvm_iojs_prefix nvm_node_prefix \
+    nvm_add_iojs_prefix nvm_strip_iojs_prefix \
+    nvm_is_iojs_version nvm_is_alias \
+    nvm_ls_remote nvm_ls_remote_iojs nvm_ls_remote_iojs_org \
+    nvm_ls nvm_remote_version nvm_remote_versions \
+    nvm_install_iojs_binary nvm_install_node_binary \
+    nvm_install_node_source \
+    nvm_version nvm_rc_version nvm_match_version \
+    nvm_ensure_default_set nvm_get_arch nvm_get_os \
+    nvm_print_implicit_alias nvm_validate_implicit_alias \
+    nvm_resolve_alias nvm_ls_current nvm_alias \
+    nvm_binary_available nvm_prepend_path nvm_strip_path \
+    nvm_num_version_groups nvm_format_version nvm_ensure_version_prefix \
+    nvm_normalize_version nvm_is_valid_version \
+    nvm_ensure_version_installed \
+    nvm_version_path nvm_alias_path nvm_version_dir \
+    nvm_find_nvmrc nvm_find_up nvm_tree_contains_path \
+    nvm_version_greater nvm_version_greater_than_or_equal_to \
+    nvm_print_npm_version nvm_npm_global_modules \
+    nvm_has_system_node nvm_has_system_iojs \
+    nvm_download nvm_get_latest nvm_has nvm_get_latest \
+    nvm_supports_source_options > /dev/null 2>&1
+  unset NVM_RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR \
+    NVM_DIR NVM_CD_FLAGS NODE_PATH NVM_PATH NVM_BIN > /dev/null 2>&1
+}
+
 # Unload any existing environment variables
-if type nvm | grep -i function > /dev/null; then
-   nvm unload
-fi
+nvm_unload
 
 NVM_SCRIPT_SOURCE="$_"
 
@@ -2073,31 +2099,7 @@ $NVM_LS_REMOTE_POST_MERGED_OUTPUT" | command grep -v "N/A" | command sed '/^$/d'
       echo "0.26.1"
     ;;
     "unload" )
-      unset -f nvm nvm_print_versions nvm_checksum \
-        nvm_iojs_prefix nvm_node_prefix \
-        nvm_add_iojs_prefix nvm_strip_iojs_prefix \
-        nvm_is_iojs_version nvm_is_alias \
-        nvm_ls_remote nvm_ls_remote_iojs nvm_ls_remote_iojs_org \
-        nvm_ls nvm_remote_version nvm_remote_versions \
-        nvm_install_iojs_binary nvm_install_node_binary \
-        nvm_install_node_source \
-        nvm_version nvm_rc_version nvm_match_version \
-        nvm_ensure_default_set nvm_get_arch nvm_get_os \
-        nvm_print_implicit_alias nvm_validate_implicit_alias \
-        nvm_resolve_alias nvm_ls_current nvm_alias \
-        nvm_binary_available nvm_prepend_path nvm_strip_path \
-        nvm_num_version_groups nvm_format_version nvm_ensure_version_prefix \
-        nvm_normalize_version nvm_is_valid_version \
-        nvm_ensure_version_installed \
-        nvm_version_path nvm_alias_path nvm_version_dir \
-        nvm_find_nvmrc nvm_find_up nvm_tree_contains_path \
-        nvm_version_greater nvm_version_greater_than_or_equal_to \
-        nvm_print_npm_version nvm_npm_global_modules \
-        nvm_has_system_node nvm_has_system_iojs \
-        nvm_download nvm_get_latest nvm_has nvm_get_latest \
-        nvm_supports_source_options > /dev/null 2>&1
-        unset NVM_RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR \
-          NVM_DIR NVM_CD_FLAGS NODE_PATH NVM_PATH NVM_BIN > /dev/null 2>&1
+      nvm_unload
     ;;
     * )
       >&2 nvm help


### PR DESCRIPTION
Fixes issues mentioned in https://github.com/creationix/nvm/pull/847 where sourcing a new installation of `nvm` will modify the previously sourced installation.

Original behavior:
```
# echo $NVM_DIR
/Users/lukechilds/.nvm

# pwd
/Users/lukechilds/Dev/oss/nvm

# source nvm.sh

# echo $NVM_DIR
/Users/lukechilds/.nvm
```
Proceeding to run `nvm uninstall x.x.x` will uninstall from the system nvm

New behavior:
```
# echo $NVM_DIR
/Users/lukechilds/.nvm

# pwd
/Users/lukechilds/Dev/oss/nvm

# source nvm.sh

# echo $NVM_DIR
/Users/lukechilds/Dev/oss/nvm
```
Proceeding to run nvm functions will install/uninstall node inside the sourced nvm installation.

This means running unit tests in a working folder can't affect the system nvm installation and also opens the possibility to run multiple nvm installations side by side.