### PR TITLE
README: Add link to a dedicated nvm wrapper for fish shell

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,8 @@ Note: `nvm` does not support Windows (see [#284](https://github.com/creationix/n
  - [nvmw](https://github.com/hakobera/nvmw)
  - [nvm-windows](https://github.com/coreybutler/nvm-windows)
 
-Note: `nvm` does not support [Fish] either (see [#303](https://github.com/creationix/nvm/issues/303)). An alternative exists, which is neither supported nor developed by us:
+Note: `nvm` does not support [Fish] either (see [#303](https://github.com/creationix/nvm/issues/303)). Alternatives exist, which are neither supported nor developed by us:
+ - [nvm](https://github.com/derekstavis/plugin-nvm) plugin for [Oh My Fish](https://github.com/oh-my-fish/oh-my-fish), which makes nvm and its completions available in fish shell
  - [bass](https://github.com/edc/bass) allows to use utilities written for Bash in fish shell
 
 ### Install script


### PR DESCRIPTION
Includes a reference to `nvm` plugin for Oh My Fish framework.