### PR TITLE
Remove -q option to curl

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -22,7 +22,7 @@ nvm_is_alias() {
 nvm_get_latest() {
   local NVM_LATEST_URL
   if nvm_has "curl"; then
-    NVM_LATEST_URL="$(curl -q -w "%{url_effective}\n" -L -s -S http://latest.nvm.sh -o /dev/null)"
+    NVM_LATEST_URL="$(curl -w "%{url_effective}\n" -L -s -S http://latest.nvm.sh -o /dev/null)"
   elif nvm_has "wget"; then
     NVM_LATEST_URL="$(wget http://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
   else
@@ -39,7 +39,7 @@ nvm_get_latest() {
 
 nvm_download() {
   if nvm_has "curl"; then
-    curl -q $*
+    curl $*
   elif nvm_has "wget"; then
     # Emulate curl with wget
     ARGS=$(echo "$*" | command sed -e 's/--progress-bar /--progress=bar /' \


### PR DESCRIPTION
The -q option forces curl to ignore .curlrc. This causes problems when curl
needs to be instructed to ignore certificate warnings (by adding 'insecure' to
.curlrc) when behind a proxy that uses self-signed certs.