### PR TITLE
Update nvm.sh

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1616,10 +1616,12 @@ nvm() {
       if [ "_$NVM_OS" = "_freebsd" ]; then
         # node.js and io.js do not have a FreeBSD binary
         nobinary=1
+        echo "Currently, there is no binary for $NVM_OS" >&2
       elif [ "_$NVM_OS" = "_sunos" ]; then
         # Not all node/io.js versions have a Solaris binary
           if ! nvm_has_solaris_binary "$VERSION"; then
             nobinary=1
+            echo "Currently, there is no binary of version $VERSION for $NVM_OS" >&2
         fi
       fi
       local NVM_INSTALL_SUCCESS


### PR DESCRIPTION
Add prompt and return non-zero when there is no binary for node version greater than v1.0.0

Currently, on FreeBSD, if we try `nvm install 4.2`, we will only get:
> Installing node v1.0 and greater from source is not currently supported

In fact I had no idea what's wrong because I didn't use `-s` parameter for it,
and then I found that there are two reasons:
1. There was no pre-built nodejs binary from official for FreeBSD, which means we need to build from source.
2. nvm doesn't support build for v1.0 and greater version from source yet.

So I think there should be a prompt message to tell the user about the reason why nvm will go to build from source, no matter it will succeed or fail.