### PR TITLE
Fix `nvm-exec` for the commands includes white-spaces

### DIFF
--- a/nvm-exec
+++ b/nvm-exec
@@ -10,4 +10,4 @@ else
   nvm use > /dev/null || (echo "No .nvmrc file found" >&2 && exit 127)
 fi
 
-exec $@
+exec "$@"

--- a/test/slow/nvm exec/Running "nvm exec 0.x" should work
+++ b/test/slow/nvm exec/Running "nvm exec 0.x" should work
@@ -6,8 +6,10 @@ die () { echo $@ ; exit 1; }
 
 nvm use 0.10
 NPM_VERSION_TEN="$(npm --version)"
+TEST_STRING="foo bar"
 
 nvm use 0.11.7 && [ "$(node --version)" = "v0.11.7" ] || die "\`nvm use\` failed!"
 
 [ "$(nvm exec 0.10 npm --version | tail -1)" = "$NPM_VERSION_TEN" ] || die "`nvm exec` failed to run with the correct version"
 
+[ "$(nvm exec 0.10 bash -c "printf '$TEST_STRING'" | tail -1)" = "$TEST_STRING" ] || die "`nvm exec` failed to run with the command include white-spaces"


### PR DESCRIPTION
Fix the below problem:

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~bash
$ nvm exec bash -c 'echo foo bar'
# no output
$
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
