### PR TITLE
install.sh - quote $DETECTED_PROFILE

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -131,7 +131,7 @@ nvm_detect_profile() {
     DETECTED_PROFILE="$HOME/.zshrc"
   fi
 
-  if [ -z $DETECTED_PROFILE ]; then
+  if [ -z "$DETECTED_PROFILE" ]; then
     if [ -f "$PROFILE" ]; then
       DETECTED_PROFILE="$PROFILE"
     elif [ -f "$HOME/.profile" ]; then
@@ -145,7 +145,7 @@ nvm_detect_profile() {
     fi
   fi
 
-  if [ ! -z $DETECTED_PROFILE ]; then
+  if [ ! -z "$DETECTED_PROFILE" ]; then
     echo "$DETECTED_PROFILE"
   fi
 }


### PR DESCRIPTION
When I run install.sh on OS X as a user with a space in my name,
I expect the script to complete without errors.
Instead two errors are thrown and the profile cannot be found.

```
bash: line 134: [: /Users/dave: binary operator expected
bash: line 148: [: /Users/dave: binary operator expected
=> Profile not found. Tried  (as defined in $PROFILE), ~/.bashrc, ~/.bash_profile, ~/.zshrc, and ~/.profile.
```