### PR TITLE
Patch for --reinstall-from on Ubuntu/bash

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1346,7 +1346,7 @@ nvm_npm_global_modules() {
   fi
 
   local INSTALLS
-  INSTALLS=$(echo "$NPMLIST" | command sed -e '/ -> / d' -e '/\(empty\)/ d' -e 's/^.* \(.*@[^ ]*\).*/\1/' -e '/^npm@[^ ]*.*$/ d' | command xargs)
+  INSTALLS=$(echo "$NPMLIST" | command sed -e '/ -> / d' -e '/\(empty\)/ d' -e 's/^.* \(.*@[^ ]*\).*/\1/' -e '/^npm@[^ ]*.*$/ d' | command xargs -0)
 
   local LINKS
   LINKS="$(echo "$NPMLIST" | command sed -n 's/.* -> \(.*\)/\1/ p')"


### PR DESCRIPTION
I had a problem with xargs when installing on Ubuntu 14, bash version:
GNU bash, version 4.3.11(1)-release (x86_64-pc-linux-gnu)
This edit fixes it