### PR TITLE
Added an Environment Variable to define a HTTP-Proxy

### DIFF
--- a/test/fast/Unit tests/nvm_has_http_proxy
+++ b/test/fast/Unit tests/nvm_has_http_proxy
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+! nvm_has_http_proxy || die 'nvm_has_http_proxy: no http_proxy defined'
+
+NVM_HTTP_PROXY=127.0.0.1:1234
+nvm_has_http_proxy || die 'nvm_has_http_proxy: http_proxy defined'


### PR DESCRIPTION
I added a environment variable `NVM_HTTP_PROXY` to define a HTTP-Proxy for all `curl` / `wget` requests `nvm` is sending.

The reason behind it was that I had a problem with CentOS7 behind a HTTP-Proxy where `nvm` simply failed to do any actions (downloading `node`, listings versions, etc...)
and after some investigation it turned out that `curl` wasn't able to download anything because it wasn't used by `nvm`. 
So I thought it would be appropriate to add a environment variable so `nvm` would use a HTTP-Proxy if `NVM_HTTP_PROXY` is set.

I also added a small unit test, to test the `nvm_has_http_proxy` function.
Maybe there is also a way to test this on travis (I didn't find something to define a "fake"-proxy)?