### PR TITLE
Do not modify parameters of sourcing script in zsh

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2377,7 +2377,8 @@ $NVM_LS_REMOTE_POST_MERGED_OUTPUT" | command grep -v "N/A" | command sed '/^$/d'
         nvm_print_npm_version nvm_npm_global_modules \
         nvm_has_system_node nvm_has_system_iojs \
         nvm_download nvm_get_latest nvm_has nvm_get_latest \
-        nvm_supports_source_options nvm_auto nvm_supports_xz > /dev/null 2>&1
+        nvm_supports_source_options nvm_auto nvm_supports_xz \
+        nvm_process_parameters > /dev/null 2>&1
       unset RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_DIR NVM_CD_FLAGS > /dev/null 2>&1
     ;;
     * )
@@ -2419,17 +2420,22 @@ nvm_auto() {
   fi
 }
 
-NVM_AUTO_MODE='use'
-if nvm_supports_source_options; then
-  while [ $# -ne 0 ]
-  do
-    case "$1" in
-      --install) NVM_AUTO_MODE='install' ;;
-      --no-use) NVM_AUTO_MODE='none' ;;
-    esac
-    shift
-  done
-fi
-nvm_auto "$NVM_AUTO_MODE"
+nvm_process_parameters() {
+  local NVM_AUTO_MODE
+  NVM_AUTO_MODE='use'
+  if nvm_supports_source_options; then
+    while [ $# -ne 0 ]
+    do
+      case "$1" in
+        --install) NVM_AUTO_MODE='install' ;;
+        --no-use) NVM_AUTO_MODE='none' ;;
+      esac
+      shift
+    done
+  fi
+  nvm_auto "$NVM_AUTO_MODE"
+}
+
+nvm_process_parameters "$@"
 
 } # this ensures the entire script is downloaded #

--- a/test/fast/Sourcing nvm.sh should not modify parameters of caller
+++ b/test/fast/Sourcing nvm.sh should not modify parameters of caller
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -- yes
+. ../../nvm.sh
+[ "$1" = yes ]


### PR DESCRIPTION
When sourcing a script without parameters in zsh the sourced scripts
gets the same parameters as the sourcing file and is able to modify
these parameters. Prevent nvm from removing all parameters of sourcing
script by processing a copy of the parameters in a function.