### PR TITLE
Trim whitespace from .nvmrc

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -141,6 +141,7 @@ nvm_rc_version() {
   NVMRC_PATH="$(nvm_find_nvmrc)"
   if [ -e "$NVMRC_PATH" ]; then
     read -r NVM_RC_VERSION < "$NVMRC_PATH"
+    NVM_RC_VERSION="$(echo "${NVM_RC_VERSION}" | sed -e 's/[[:space:]]*$//')"
     echo "Found '$NVMRC_PATH' with version <$NVM_RC_VERSION>"
   else
     >&2 echo "No .nvmrc file found"

--- a/test/fast/Running "nvm use" should strip windows line-endings from nvmrc.
+++ b/test/fast/Running "nvm use" should strip windows line-endings from nvmrc.
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+die () { echo $@ ; cleanup ; exit 1; }
+
+cleanup() {
+  rm -rf .nvmrc
+}
+
+. ../../nvm.sh
+
+# Use a known different version, first.
+nvm install v5.6.0 >/dev/null 2>/dev/null
+nvm use v5.6.0 >/dev/null 2>/dev/null
+
+# Verify we're using the version we think.
+OUTPUT="$(nvm current)"
+EXPECTED_OUTPUT="v5.6.0"
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "Expected nvm to be using version $EXPECTED_OUTPUT, but 'nvm current' said $OUTPUT"
+
+# Write out .nvmrc with windows line-endings.
+printf 'v5.5.0\r\n' > .nvmrc
+
+nvm install >/dev/null 2>/dev/null
+EXIT_CODE=$?
+[ "_$EXIT_CODE" = "_0" ] \
+  || die "Expected 'nvm install' to return a successful exit code; got $EXIT_CODE"
+
+nvm use >/dev/null 2>/dev/null
+EXIT_CODE=$?
+[ "_$EXIT_CODE" = "_0" ] \
+  || die "Expected 'nvm use' to return a successful exit code; got $EXIT_CODE"
+
+OUTPUT="$(nvm current)"
+EXPECTED_OUTPUT="v5.5.0"
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "Expected nvm to be using version $EXPECTED_OUTPUT from .nvmrc, but 'nvm current' said $OUTPUT"
+
+cleanup
+


### PR DESCRIPTION
This strips trailing whitespace from the version as read from .nvmrc before attempting to use it.
Added a test for it, but not too familiar with this type of testing, so not sure how good of a test
it is.

Also had some trouble running the tests in general, even before I made any changes, I had some issues.
So somebody should definitely verify this all before merging.

Fixes #1015.