### PR TITLE
Added note about OSX's missing .bash_profile file.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,6 +38,8 @@ Eg: `curl ... | NVM_DIR="path/to/nvm" bash`
 
 <sub>*NB. The installer can use `git`, `curl`, or `wget` to download `nvm`, whatever is available.*</sub>
 
+Note: On OSX, if you get `nvm: command not found` after running the install script, your system may not have a [.bash_profile file] where the command is set up. Simple create one with `touch ~/.bash_profile` and run the install script again.
+
 ### Manual install
 
 For manual install create a folder somewhere in your filesystem with the `nvm.sh` file inside it. I put mine in `~/.nvm`.


### PR DESCRIPTION
Just a note/fix for a hiccup I ran into installing from the script file on OS X [Yosemite]. Go figure, I somehow didn't have a .bash_profile file on this machine yet.

(Solution originally [found on Stack Overflow](http://stackoverflow.com/a/30031102/48700), where I added similar steps for future visitors.)