### PR TITLE
Unset NVM_BIN when is not necessary

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1870,6 +1870,7 @@ nvm() {
           echo "$NVM_DIR/*/lib/node_modules removed from \$NODE_PATH"
         fi
       fi
+      unset NVM_BIN NVM_PATH
     ;;
     "use" )
       local PROVIDED_VERSION

--- a/test/fast/Running "nvm deactivate" should unset the nvm environment variables.
+++ b/test/fast/Running "nvm deactivate" should unset the nvm environment variables.
@@ -10,8 +10,12 @@ die () { echo $@ ; exit 1; }
 nvm use --delete-prefix v0.2.3 || die "Failed to activate v0.2.3"
 [ `expr "$PATH" : ".*v0.2.3/.*/bin"` != 0 ] || die "PATH not set up properly"
 [ `expr "$NODE_PATH" : ".*v0.2.3/.*/lib/node_modules"` = 0 ] || die "NODE_PATH should not contain (npm root -g)"
+[ `expr "$NVM_BIN" : ".*v0.2.3/bin"` != 0 ] || die "NODE_BIN should contain bin directory path"
+[ `expr "$NVM_PATH" : ".*v0.2.3/lib/node"` != 0 ] || die "NODE_PATH should contain lib node directory path"
 # ^ note: NODE_PATH should not contain `npm root -g` since globals should not be requireable
 
 nvm deactivate || die "Failed to deactivate v0.2.3"
 [ `expr "$PATH" : ".*v0.2.3/.*/bin"` = 0 ] || die "PATH not cleaned properly"
 [ `expr "$NODE_PATH" : ".*v0.2.3/.*/lib/node_modules"` = 0 ] || die "NODE_PATH not cleaned properly"
+[ "_$NVM_BIN" = "_" ] || die "NVM_BIN should be unset: got '$NVM_BIN'"
+[ "_$NVM_PATH" = "_" ] || die "NVM_PATH should be unset: got '$NVM_PATH'"


### PR DESCRIPTION
I would like to know if my current shell are using a node configured by the nvm.
But the are only 3 cheap ways to know

- check if there are the nvm directory on PATH
- check the version using the NVM_BIN or NVM_PATH

Using the NVM_BIN is very simple. Using this simple function:
```bash
function __node_ps1() {
  if [[ ! -z "$NVM_BIN" ]]; then
    local array=(${NVM_BIN//// })
    local version=${array[-2]}
    echo " js(${version##*v})"
  fi
}
```

But after a `nvm deactivate` or `nvm use system` the nvm keep these environment variables.