### PR TITLE
Explicitly fetch tags in the manual update

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -73,7 +73,7 @@ Add these lines to your `~/.bashrc`, `~/.profile`, or `~/.zshrc` file to have it
 
 For manual upgrade with `git`, change to the `$NVM_DIR`, pull down the latest changes, and check out the latest version:
 
-    cd "$NVM_DIR" && git pull origin master && git checkout `git describe --abbrev=0 --tags`
+    cd "$NVM_DIR" && git fetch origin && git checkout `git describe --abbrev=0 --tags`
 
 After upgrading, don't forget to activate the new version:
 


### PR DESCRIPTION
On updating `nvm` using the manual instructions, I noticed the tags weren't getting pulled in so I ended up on the same version.

Steps to reproduce:
Run the manual update line in `README.markdown`

What do you expect:
To end up on the most recent version of `nvm`

What happens:
You end up on the same version of `nvm`

On older versions of git this change will only pull tags (as opposed to tags and branches), but given it's part of a chain of commands that only use tags, I think that's ok?

Thanks for the great library.