### PR TITLE
Use `language: generic` in `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c # defaults to ruby
+language: generic
 addons:
   apt_packages:
   - zsh


### PR DESCRIPTION
Since the tests don't rely on / [fall into](https://github.com/creationix/nvm/commit/47bbf93f5003cc695e572d2fd572c13a4ac879e5) any of the [language categories](https://docs.travis-ci.com/user/languages/) defined by Travis CI, [`language: generic`](https://github.com/travis-ci/travis-ci/issues/4895#issuecomment-150703192) can be used.