### PR TITLE
`npm config get prefix` to background

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1534,22 +1534,26 @@ nvm_die_on_prefix() {
     return
   fi
 
-  local NVM_NPM_PREFIX
-  NVM_NPM_PREFIX="$(NPM_CONFIG_LOGLEVEL=warn npm config get prefix)"
-  if ! (nvm_tree_contains_path "$NVM_DIR" "$NVM_NPM_PREFIX" >/dev/null 2>&1); then
-    if [ "_$NVM_DELETE_PREFIX" = "_1" ]; then
-      NPM_CONFIG_LOGLEVEL=warn npm config delete prefix
-    else
-      nvm deactivate >/dev/null 2>&1
-      echo >&2 "nvm is not compatible with the npm config \"prefix\" option: currently set to \"$NVM_NPM_PREFIX\""
-      if nvm_has 'npm'; then
-        echo >&2 "Run \`npm config delete prefix\` or \`$NVM_COMMAND\` to unset it."
+  check_prefix() {
+    local NVM_NPM_PREFIX
+    NVM_NPM_PREFIX="$(NPM_CONFIG_LOGLEVEL=warn npm config get prefix 2>&1)"
+    if ! (nvm_tree_contains_path "$NVM_DIR" "$NVM_NPM_PREFIX" >/dev/null 2>&1); then
+      if [ "_$NVM_DELETE_PREFIX" = "_1" ]; then
+        NPM_CONFIG_LOGLEVEL=warn npm config delete prefix
       else
-        echo >&2 "Run \`$NVM_COMMAND\` to unset it."
+        nvm deactivate >/dev/null 2>&1
+        echo >&2 ""
+        echo >&2 "nvm is not compatible with the npm config \"prefix\" option: currently set to \"$NVM_NPM_PREFIX\""
+        if nvm_has 'npm'; then
+          echo >&2 "Run \`npm config delete prefix\` or \`$NVM_COMMAND\` to unset it."
+        else
+          echo >&2 "Run \`$NVM_COMMAND\` to unset it."
+        fi
+        return 10
       fi
-      return 10
     fi
-  fi
+  }
+  (check_prefix &)
 }
 
 # Succeeds if $IOJS_VERSION represents an io.js version that has a


### PR DESCRIPTION
Hello,

referring to https://github.com/creationix/nvm/issues/860, a possibility to reduce nvm-sourcing time by sending the `npm config get prefix` command to a background task. For me, it reduces the time by more than a half.

There is one inconvenience when deleting a previously set prefix via `nvm use --delete-prefix v6.0.0`, I think related to https://github.com/creationix/nvm/pull/1006, the cursor is set to an awkward position, but e.g. pressing Ctrl-C brings it to a normal position.

I manually tested `sh`,`bash`,`zsh` and `ksh` in interactive mode. `ksh` is not working for me, it doesn't know the `local` keyword (thus unrelated). There are no tests yet as I don't know whether backgrounding is an acceptable solution. It could be enabled for interactive mode and disabled for non-interactive mode maybe. As it is a warning for non-spec-compliant use, an asynchronous warning may be sufficient.

I had to redirect npm's &2 to &1 so that it didn't cause the cursor to move to awkward position on every sourcing.

Best regards, Adam