### PR TITLE
`nvm upgrade`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,40 +3,49 @@ addons:
   apt_packages:
   - zsh
   - ksh
+
 before_install:
   - curl --version
   - wget --version
+
 install:
   - (mkdir /tmp/urchin && cd /tmp/urchin && curl -s "$(curl -s https://registry.npmjs.com/urchin | grep -Eo '"tarball":\s*"[^"]+"' | tail -n 1 | awk -F\" '{ print $4 }')" -O && tar -x -f urchin*)
   - chmod +x /tmp/urchin/package/urchin
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
+
 script:
   - export PATH=$(echo $PATH | sed 's/::/:/')
   - NVM_DIR=$TRAVIS_BUILD_DIR make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin/package/urchin test-$SHELL
+
 env:
   - SHELL=bash TEST_SUITE=install_script
+
   - SHELL=sh TEST_SUITE=fast
   - SHELL=dash TEST_SUITE=fast
   - SHELL=bash TEST_SUITE=fast
   - SHELL=zsh TEST_SUITE=fast
-#  - SHELL=ksh TEST_SUITE=fast
+  # - SHELL=ksh TEST_SUITE=fast
+
   - SHELL=sh TEST_SUITE=slow
   - SHELL=dash TEST_SUITE=slow
   - SHELL=bash TEST_SUITE=slow
   - SHELL=zsh TEST_SUITE=slow
-#  - SHELL=ksh TEST_SUITE=slow
+  # - SHELL=ksh TEST_SUITE=slow
+
   - SHELL=sh TEST_SUITE=sourcing
   - SHELL=dash TEST_SUITE=sourcing
   - SHELL=bash TEST_SUITE=sourcing
   - SHELL=zsh TEST_SUITE=sourcing
-#  - SHELL=ksh TEST_SUITE=sourcing
+  # - SHELL=ksh TEST_SUITE=sourcing
+
   - SHELL=sh TEST_SUITE=installation
-#  - SHELL=sh TEST_SUITE=installation WITHOUT_CURL=1
   - SHELL=dash TEST_SUITE=installation
-#  - SHELL=dash TEST_SUITE=installation WITHOUT_CURL=1
   - SHELL=bash TEST_SUITE=installation
-#  - SHELL=bash TEST_SUITE=installation WITHOUT_CURL=1
   - SHELL=zsh TEST_SUITE=installation
-#  - SHELL=zsh TEST_SUITE=installation WITHOUT_CURL=1
-#  - SHELL=ksh TEST_SUITE=installation
-#  - SHELL=ksh TEST_SUITE=installation WITHOUT_CURL=1
+  # - SHELL=ksh TEST_SUITE=installation
+
+  # - SHELL=sh TEST_SUITE=installation WITHOUT_CURL=1
+  # - SHELL=dash TEST_SUITE=installation WITHOUT_CURL=1
+  # - SHELL=bash TEST_SUITE=installation WITHOUT_CURL=1
+  # - SHELL=zsh TEST_SUITE=installation WITHOUT_CURL=1
+  # - SHELL=ksh TEST_SUITE=installation WITHOUT_CURL=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,49 +3,40 @@ addons:
   apt_packages:
   - zsh
   - ksh
-
 before_install:
   - curl --version
   - wget --version
-
 install:
   - (mkdir /tmp/urchin && cd /tmp/urchin && curl -s "$(curl -s https://registry.npmjs.com/urchin | grep -Eo '"tarball":\s*"[^"]+"' | tail -n 1 | awk -F\" '{ print $4 }')" -O && tar -x -f urchin*)
   - chmod +x /tmp/urchin/package/urchin
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
-
 script:
   - export PATH=$(echo $PATH | sed 's/::/:/')
   - NVM_DIR=$TRAVIS_BUILD_DIR make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin/package/urchin test-$SHELL
-
 env:
   - SHELL=bash TEST_SUITE=install_script
-
   - SHELL=sh TEST_SUITE=fast
   - SHELL=dash TEST_SUITE=fast
   - SHELL=bash TEST_SUITE=fast
   - SHELL=zsh TEST_SUITE=fast
-  # - SHELL=ksh TEST_SUITE=fast
-
+#  - SHELL=ksh TEST_SUITE=fast
   - SHELL=sh TEST_SUITE=slow
   - SHELL=dash TEST_SUITE=slow
   - SHELL=bash TEST_SUITE=slow
   - SHELL=zsh TEST_SUITE=slow
-  # - SHELL=ksh TEST_SUITE=slow
-
+#  - SHELL=ksh TEST_SUITE=slow
   - SHELL=sh TEST_SUITE=sourcing
   - SHELL=dash TEST_SUITE=sourcing
   - SHELL=bash TEST_SUITE=sourcing
   - SHELL=zsh TEST_SUITE=sourcing
-  # - SHELL=ksh TEST_SUITE=sourcing
-
+#  - SHELL=ksh TEST_SUITE=sourcing
   - SHELL=sh TEST_SUITE=installation
+#  - SHELL=sh TEST_SUITE=installation WITHOUT_CURL=1
   - SHELL=dash TEST_SUITE=installation
+#  - SHELL=dash TEST_SUITE=installation WITHOUT_CURL=1
   - SHELL=bash TEST_SUITE=installation
+#  - SHELL=bash TEST_SUITE=installation WITHOUT_CURL=1
   - SHELL=zsh TEST_SUITE=installation
-  # - SHELL=ksh TEST_SUITE=installation
-
-  # - SHELL=sh TEST_SUITE=installation WITHOUT_CURL=1
-  # - SHELL=dash TEST_SUITE=installation WITHOUT_CURL=1
-  # - SHELL=bash TEST_SUITE=installation WITHOUT_CURL=1
-  # - SHELL=zsh TEST_SUITE=installation WITHOUT_CURL=1
-  # - SHELL=ksh TEST_SUITE=installation WITHOUT_CURL=1
+#  - SHELL=zsh TEST_SUITE=installation WITHOUT_CURL=1
+#  - SHELL=ksh TEST_SUITE=installation
+#  - SHELL=ksh TEST_SUITE=installation WITHOUT_CURL=1

--- a/nvm.sh
+++ b/nvm.sh
@@ -1954,6 +1954,42 @@ nvm() {
       fi
       return $?
     ;;
+    "upgrade" )
+      local current_version
+      current_version="$(nvm_ls_current)"
+
+      if [ $current_version = "none" ]; then
+        nvm_err 'No version currently active, cannot upgrade'
+        return 1
+      fi
+
+      if [ $current_version = "system" ]; then
+        nvm_err 'Cannot upgrade the system version of node'
+        return 1
+      fi
+
+      local semver_major
+      semver_major="$(echo $current_version | sed 's/v\([0-9]\+\)\.\([0-9]\+\).*/\1/')"
+
+      local semver_minor
+      semver_minor="$(echo $current_version | sed 's/v\([0-9]\+\)\.\([0-9]\+\).*/\2/')"
+
+      local install_version
+      if [ $semver_major = '0' ]; then
+        install_version="v0.$semver_minor"
+      else
+        install_version="v$semver_major"
+      fi
+
+      if ! nvm_is_valid_version $install_version; then
+        nvm_err 'Failed to determine current version'
+        return 1
+      fi
+
+      nvm_echo "Upgrading $current_version to the latest $install_version"
+      nvm install $install_version --reinstall-packages-from=$current_version
+      return $?
+    ;;
     "uninstall" )
       if [ $# -ne 2 ]; then
         >&2 nvm --help

--- a/nvm.sh
+++ b/nvm.sh
@@ -1955,24 +1955,33 @@ nvm() {
       return $?
     ;;
     "upgrade" )
-      local current_version
-      current_version="$(nvm_ls_current)"
+      local base_version
+      base_version="$(nvm_ls_current)"
 
-      if [ $current_version = "none" ]; then
+      if [ $# -ge 2 ]; then
+        base_version="$(nvm_match_version $2)"
+
+        if [ $base_version = "N/A" ]; then
+          nvm_err 'Cannot find the specified version'
+          return 1
+        fi
+      fi
+
+      if [ $base_version = "none" ]; then
         nvm_err 'No version currently active, cannot upgrade'
         return 1
       fi
 
-      if [ $current_version = "system" ]; then
+      if [ $base_version = "system" ]; then
         nvm_err 'Cannot upgrade the system version of node'
         return 1
       fi
 
       local semver_major
-      semver_major="$(echo $current_version | sed 's/v\([0-9]\+\)\.\([0-9]\+\).*/\1/')"
+      semver_major="$(echo $base_version | sed 's/v\([0-9]\+\)\.\([0-9]\+\).*/\1/')"
 
       local semver_minor
-      semver_minor="$(echo $current_version | sed 's/v\([0-9]\+\)\.\([0-9]\+\).*/\2/')"
+      semver_minor="$(echo $base_version | sed 's/v\([0-9]\+\)\.\([0-9]\+\).*/\2/')"
 
       local install_version
       if [ $semver_major = '0' ]; then
@@ -1986,8 +1995,8 @@ nvm() {
         return 1
       fi
 
-      nvm_echo "Upgrading $current_version to the latest $install_version"
-      nvm install $install_version --reinstall-packages-from=$current_version
+      nvm_echo "Upgrading $base_version to the latest $install_version"
+      nvm install $install_version --reinstall-packages-from=$base_version
       return $?
     ;;
     "uninstall" )

--- a/nvm.sh
+++ b/nvm.sh
@@ -1740,6 +1740,7 @@ nvm() {
       nvm_echo '  nvm --version                             Print out the latest released version of nvm'
       nvm_echo '  nvm install [-s] <version>                Download and install a <version>, [-s] from source. Uses .nvmrc if available'
       nvm_echo '    --reinstall-packages-from=<version>     When installing, reinstall packages installed in <node|iojs|node version number>'
+      nvm_echo '  nvm upgrade [<version>]                   Upgrade to the latest minor/patch version'
       nvm_echo '  nvm uninstall <version>                   Uninstall a version'
       nvm_echo '  nvm use [--silent] <version>              Modify PATH to use <version>. Uses .nvmrc if available'
       nvm_echo '  nvm exec [--silent] <version> [<command>] Run <command> on <version>. Uses .nvmrc if available'

--- a/test/slow/nvm upgrade/Running "nvm upgrade" installs latest v0.12
+++ b/test/slow/nvm upgrade/Running "nvm upgrade" installs latest v0.12
@@ -2,8 +2,9 @@
 
 die () { echo $@ ; exit 1; }
 
-# Source nvm
+# Source nvm and activate 0.12.0
 . ../../../nvm.sh
+nvm use 0.12.0
 
 # Install some global packages
 npm install -g npm || die "npm install -g npm failed"

--- a/test/slow/nvm upgrade/Running "nvm upgrade" installs latest v0.12
+++ b/test/slow/nvm upgrade/Running "nvm upgrade" installs latest v0.12
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+# Source nvm
+. ../../../nvm.sh
+
+# Install some global packages
+npm install -g npm || die "npm install -g npm failed"
+npm install -g object-is@0.0.0 || die "npm install -g object-is failed"
+npm list --global | grep object-is > /dev/null || die "object-is isn't installed"
+
+# Upgrade it
+nvm upgrade || die "Failed to run nvm upgrade"
+
+# Uninstall old version
+nvm uninstall 0.12.0
+
+# Make sure a newer version of 0.12 is still installed
+nvm ls | grep v0.12
+[ "$?" = "0" ] || die "Failed to upgrade node"

--- a/test/slow/nvm upgrade/setup_dir
+++ b/test/slow/nvm upgrade/setup_dir
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. ../../../nvm.sh
+nvm install 0.12.0
+nvm use 0.12.0

--- a/test/slow/nvm upgrade/setup_dir
+++ b/test/slow/nvm upgrade/setup_dir
@@ -2,4 +2,3 @@
 
 . ../../../nvm.sh
 nvm install 0.12.0
-nvm use 0.12.0

--- a/test/slow/nvm upgrade/teardown_dir
+++ b/test/slow/nvm upgrade/teardown_dir
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. ../../../nvm.sh
+nvm uninstall 0.12
+nvm deactivate


### PR DESCRIPTION
Fixes creationix/nvm#1091 by adding `nvm upgrade [<version>]`, which parses the current or specified version of node, installs the latest compatible version (eg 0.12.x, 5.x, 6.x, etc), and reinstalls all global packages into the new version.

I still need to add a few more tests, but feedback would appreciated.