### PR TITLE
Fix is variable set test

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2166,7 +2166,7 @@ nvm() {
           return 11
         fi
       fi
-      if [ -n "$NVM_USE_OUTPUT" ]; then
+      if [ -n "${NVM_USE_OUTPUT-}" ]; then
         nvm_echo "$NVM_USE_OUTPUT"
       fi
     ;;


### PR DESCRIPTION
# Issue

Currently, using the `nvm.sh` script from another script where the check for unbound variables is on (`set -u`) will give the following error:

```
NVM_USE_OUTPUT: unbound variable
```

# Note

The issue described above occurs on an Ubuntu 14-04 environment Bash version 4.3.11.
However, it didn't occur on my MacBook Pro (v10.11.4) with Bash version 3.2.57.