### PR TITLE
Use arm64 packages on aarch64

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1145,6 +1145,7 @@ nvm_get_arch() {
   case "$HOST_ARCH" in
     x86_64 | amd64) NVM_ARCH="x64" ;;
     i*86) NVM_ARCH="x86" ;;
+    aarch64) NVM_ARCH="arm64" ;;
     *) NVM_ARCH="$HOST_ARCH" ;;
   esac
   nvm_echo "${NVM_ARCH}"


### PR DESCRIPTION
To install nodejs on aarch64 architecture you need to use arm64 packages. I just added new  case to set correct $HOST_ARCH in this case.