### PR TITLE
fix arch on linux mint

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1143,7 +1143,7 @@ nvm_get_arch() {
 
   local NVM_ARCH
   case "$HOST_ARCH" in
-    x86_64 | amd64) NVM_ARCH="x64" ;;
+    *x86_64* | amd64) NVM_ARCH="x64" ;;
     i*86) NVM_ARCH="x86" ;;
     *) NVM_ARCH="$HOST_ARCH" ;;
   esac


### PR DESCRIPTION
I am using Linux Mint on a VirtualBox machine. And I got
```
$ uname
Linux vbl-abr-mint 3.19.0-32-generic #37~14.04.1-Ubuntu SMP Thu Oct 22 09:41:40 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux
 $ uname -a
Linux vbl-abr-mint 3.19.0-32-generic #37~14.04.1-Ubuntu SMP Thu Oct 22 09:41:40 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux
 $ uname -m
Linux vbl-abr-mint 3.19.0-32-generic #37~14.04.1-Ubuntu SMP Thu Oct 22 09:41:40 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux
```

So I changed the MVN_ARCH detection to match on *x86_64*

