### PR TITLE
Update readme default version instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -152,9 +152,9 @@ To restore your PATH, you can deactivate it:
 
     nvm deactivate
 
-To set a default Node version to be used in any new shell, use the alias 'default':
+To set a default Node version to be used in any new shell, use the alias 'default' and the version number you want to use, e.g. 5.0:
 
-    nvm alias default node
+    nvm alias default 5.0
 
 To use a mirror of the node binaries, set `$NVM_NODEJS_ORG_MIRROR`:
 


### PR DESCRIPTION
I was trying to set this and found it confusing, thought I needed to write `node`:

```
$ nvm alias default node 4.0
default -> node (-> v6.2.2)
$ nvm alias default 4.0
default -> 4.0 (-> v4.0.0)
```
