### PR TITLE
Improve error messages for missing versions

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -256,11 +256,15 @@ nvm_ensure_version_installed() {
   if [ "_$EXIT_CODE" != "_0" ] || ! nvm_is_version_installed "$LOCAL_VERSION"; then
     VERSION="$(nvm_resolve_alias "$PROVIDED_VERSION")"
     if [ $? -eq 0 ]; then
-      nvm_err "N/A: version \"$PROVIDED_VERSION -> $VERSION\" is not yet installed"
+      nvm_err "N/A: version \"$PROVIDED_VERSION -> $VERSION\" is not yet installed. 
+      
+You need to run \"npm install $PROVIDED_VERSION\" to install it before using it."
     else
       local PREFIXED_VERSION
       PREFIXED_VERSION="$(nvm_ensure_version_prefix "$PROVIDED_VERSION")"
-      nvm_err "N/A: version \"${PREFIXED_VERSION:-$PROVIDED_VERSION}\" is not yet installed"
+      nvm_err "N/A: version \"${PREFIXED_VERSION:-$PROVIDED_VERSION}\" is not yet installed.
+      
+You need to run \"npm install $PROVIDED_VERSION\" to install it before using it."
     fi
     return 1
   fi

--- a/nvm.sh
+++ b/nvm.sh
@@ -256,15 +256,15 @@ nvm_ensure_version_installed() {
   if [ "_$EXIT_CODE" != "_0" ] || ! nvm_is_version_installed "$LOCAL_VERSION"; then
     VERSION="$(nvm_resolve_alias "$PROVIDED_VERSION")"
     if [ $? -eq 0 ]; then
-      nvm_err "N/A: version \"$PROVIDED_VERSION -> $VERSION\" is not yet installed. 
-      
-You need to run \"npm install $PROVIDED_VERSION\" to install it before using it."
+      nvm_err "N/A: version \"$PROVIDED_VERSION -> $VERSION\" is not yet installed."
+      nvm_err ""
+      nvm_err "You need to run \"nvm install $PROVIDED_VERSION\" to install it before using it."
     else
       local PREFIXED_VERSION
       PREFIXED_VERSION="$(nvm_ensure_version_prefix "$PROVIDED_VERSION")"
-      nvm_err "N/A: version \"${PREFIXED_VERSION:-$PROVIDED_VERSION}\" is not yet installed.
-      
-You need to run \"npm install $PROVIDED_VERSION\" to install it before using it."
+      nvm_err "N/A: version \"${PREFIXED_VERSION:-$PROVIDED_VERSION}\" is not yet installed."
+      nvm_err ""
+      nvm_err "You need to run \"nvm install $PROVIDED_VERSION\" to install it before using it."
     fi
     return 1
   fi

--- a/test/fast/Unit tests/nvm_ensure_version_installed
+++ b/test/fast/Unit tests/nvm_ensure_version_installed
@@ -11,7 +11,9 @@ mkdir -p "$(nvm_version_path v0.1.2)"
 
 OUTPUT="$(nvm_ensure_version_installed foo 2>&1)"
 EXIT_CODE=$?
-EXPECTED_OUTPUT='N/A: version "foo" is not yet installed'
+EXPECTED_OUTPUT='N/A: version "foo" is not yet installed.
+
+You need to run "nvm install foo" to install it before using it.'
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "expected 'nvm_ensure_version_installed foo' to give $EXPECTED_OUTPUT, got $OUTPUT"
 [ "_$EXIT_CODE" = "_1" ] || die "expected 'nvm_ensure_version_installed foo' to exit with 1, got $EXIT_CODE"
 
@@ -23,7 +25,9 @@ EXIT_CODE=$?
 # Special case for "iojs"
 OUTPUT="$(nvm_ensure_version_installed iojs 2>&1)"
 EXIT_CODE=$?
-EXPECTED_OUTPUT='N/A: version "iojs" is not yet installed'
+EXPECTED_OUTPUT='N/A: version "iojs" is not yet installed.
+
+You need to run "nvm install iojs" to install it before using it.'
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "expected 'nvm_ensure_version_installed iojs' to give $EXPECTED_OUTPUT, got $OUTPUT"
 [ "_$EXIT_CODE" = "_1" ] || die "expected 'nvm_ensure_version_installed iojs' to exit with 1, got $EXIT_CODE"
 

--- a/test/slow/nvm run/Running "nvm run 0.x" should error out sensibly when 0.x is not installed
+++ b/test/slow/nvm run/Running "nvm run 0.x" should error out sensibly when 0.x is not installed
@@ -5,5 +5,12 @@ die () { echo $@ ; exit 1; }
 
 . ../../../nvm.sh
 
-[ "$(nvm run 0.2 --version 2>&1)" = 'N/A: version "v0.2" is not yet installed' ] || die "\`nvm run\` with an uninstalled node version failed to error out correctly"
-[ "$(nvm run iojs-0.2 --version 2>&1)" = 'N/A: version "iojs-v0.2" is not yet installed' ] || die "\`nvm run\` with an uninstalled iojs version failed to error out correctly"
+EXPECTED_OUTPUT='N/A: version "v0.2" is not yet installed.
+
+You need to run "nvm install 0.2" to install it before using it.'
+[ "_$(nvm run 0.2 --version 2>&1)" = "_$EXPECTED_OUTPUT" ] || die "\`nvm run\` with an uninstalled node version failed to error out correctly"
+
+EXPECTED_OUTPUT='N/A: version "iojs-v0.2" is not yet installed.
+
+You need to run "nvm install iojs-0.2" to install it before using it.'
+[ "_$(nvm run iojs-0.2 --version 2>&1)" = "_$EXPECTED_OUTPUT" ] || die "\`nvm run\` with an uninstalled iojs version failed to error out correctly"


### PR DESCRIPTION
`nvm use`, `nvm run` and others check if the version is installed before executing Node, but the error message could be clearer on what steps the user has to take to achieve what they want, this makes that clearer by telling the user which commands they need to run.