### PR TITLE
Clears "NVM_NODEJS_ORG_MIRROR is deprecated" node-gyp warning

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -121,6 +121,10 @@ if [ -z "${NVM_NODEJS_ORG_MIRROR-}" ]; then
   export NVM_NODEJS_ORG_MIRROR="https://nodejs.org/dist"
 fi
 
+if [ -z "${NODEJS_ORG_MIRROR-}" ]; then
+  export NODEJS_ORG_MIRROR="https://nodejs.org/dist"
+fi
+
 if [ -z "${NVM_IOJS_ORG_MIRROR-}" ]; then
   export NVM_IOJS_ORG_MIRROR="https://iojs.org/dist"
 fi


### PR DESCRIPTION
Clears node-gyp warning:

```
gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
```

https://github.com/nodejs/node-gyp/blob/d460084b241c427655497a1de4ed351a13ffb47f/lib/process-release.js#L66-L73