### PR TITLE
Improve clarity of readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,8 +53,6 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
 ```
 
-Where 'user' in the above NVM_DIR exported path is substituted for the current logged in user.
-
 You can customize the install source, directory, profile, and version using the `NVM_SOURCE`, `NVM_DIR`, `PROFILE`, and `NODE_VERSION` variables.
 Eg: `curl ... | NVM_DIR=/usr/local/nvm bash` for a global install.
 

--- a/README.markdown
+++ b/README.markdown
@@ -49,7 +49,7 @@ wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | 
 <sub>The script clones the nvm repository to `~/.nvm` and adds the following source lines to your profile (`~/.bash_profile`, `~/.zshrc`, `~/.profile`, or `~/.bashrc`).</sub>
 
 ```
-export NVM_DIR="/home/user/.nvm"
+export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
 ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,14 @@ or Wget:
 wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash
 ```
 
-<sub>The script clones the nvm repository to `~/.nvm` and adds the source line to your profile (`~/.bash_profile`, `~/.zshrc`, `~/.profile`, or `~/.bashrc`).</sub>
+<sub>The script clones the nvm repository to `~/.nvm` and adds the following source lines to your profile (`~/.bash_profile`, `~/.zshrc`, `~/.profile`, or `~/.bashrc`).</sub>
+
+```
+export NVM_DIR="/home/user/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
+```
+
+Where 'user' in the above NVM_DIR exported path is substituted for the current logged in user.
 
 You can customize the install source, directory, profile, and version using the `NVM_SOURCE`, `NVM_DIR`, `PROFILE`, and `NODE_VERSION` variables.
 Eg: `curl ... | NVM_DIR=/usr/local/nvm bash` for a global install.


### PR DESCRIPTION
Include lines that the script will attempt to add to the profile files. Helps users diagnose which lines to expect to see in their profile files if they are having difficulty getting 'nvm' to work at the command line.