### PR TITLE
Improve installation and upgrade instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,16 +81,18 @@ which should output 'nvm' if the installation was successful. Please note that `
 
 For manual install create a folder somewhere in your filesystem with the `nvm.sh` file inside it. I put mine in `~/.nvm`.
 
-Or if you have `git` installed, then just clone it, and check out the latest version:
+Or if you have `git` installed:
+
+1. clone this repo
+1. check out the latest version
+1. activate nvm by sourcing it from your shell
 
 ```sh
-git clone https://github.com/creationix/nvm.git ~/.nvm && cd ~/.nvm && git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" origin`
-```
-
-To activate nvm, you need to source it from your shell:
-
-```sh
-. ~/.nvm/nvm.sh
+(
+  git clone https://github.com/creationix/nvm.git ~/.nvm
+  cd ~/.nvm
+  git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" origin`
+) && . ~/.nvm/nvm.sh
 ```
 
 Add these lines to your `~/.bashrc`, `~/.profile`, or `~/.zshrc` file to have it automatically sourced upon login:
@@ -103,16 +105,19 @@ export NVM_DIR="$HOME/.nvm"
 
 ### Manual upgrade
 
-For manual upgrade with `git`, change to the `$NVM_DIR`, pull down the latest changes, and check out the latest version:
+For manual upgrade with `git`:
+
+1. change to the `$NVM_DIR`
+1. pull down the latest changes
+1. check out the latest version
+1. activate the new version
 
 ```sh
-cd "$NVM_DIR" && git fetch origin && git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" origin`
-```
-
-After upgrading, don't forget to activate the new version:
-
-```sh
-. "$NVM_DIR/nvm.sh"
+(
+  cd "$NVM_DIR"
+  git fetch origin
+  git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" origin`
+) && . "$NVM_DIR/nvm.sh"
 ```
 
 ## Usage

--- a/README.markdown
+++ b/README.markdown
@@ -84,7 +84,7 @@ For manual install create a folder somewhere in your filesystem with the `nvm.sh
 Or if you have `git` installed, then just clone it, and check out the latest version:
 
 ```sh
-git clone https://github.com/creationix/nvm.git ~/.nvm && cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`
+git clone https://github.com/creationix/nvm.git ~/.nvm && cd ~/.nvm && git checkout `git describe --abbrev=0 --tags origin`
 ```
 
 To activate nvm, you need to source it from your shell:
@@ -106,7 +106,7 @@ export NVM_DIR="$HOME/.nvm"
 For manual upgrade with `git`, change to the `$NVM_DIR`, pull down the latest changes, and check out the latest version:
 
 ```sh
-cd "$NVM_DIR" && git fetch origin && git checkout `git describe --abbrev=0 --tags`
+cd "$NVM_DIR" && git fetch origin && git checkout `git describe --abbrev=0 --tags origin`
 ```
 
 After upgrading, don't forget to activate the new version:

--- a/README.markdown
+++ b/README.markdown
@@ -88,11 +88,11 @@ Or if you have `git` installed:
 1. activate nvm by sourcing it from your shell
 
 ```sh
-(
-  git clone https://github.com/creationix/nvm.git ~/.nvm
-  cd ~/.nvm
+export NVM_DIR="$HOME/.nvm" && (
+  git clone https://github.com/creationix/nvm.git "$NVM_DIR"
+  cd "$NVM_DIR"
   git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" origin`
-) && . ~/.nvm/nvm.sh
+) && . "$NVM_DIR/nvm.sh"
 ```
 
 Add these lines to your `~/.bashrc`, `~/.profile`, or `~/.zshrc` file to have it automatically sourced upon login:

--- a/README.markdown
+++ b/README.markdown
@@ -84,7 +84,7 @@ For manual install create a folder somewhere in your filesystem with the `nvm.sh
 Or if you have `git` installed, then just clone it, and check out the latest version:
 
 ```sh
-git clone https://github.com/creationix/nvm.git ~/.nvm && cd ~/.nvm && git checkout `git describe --abbrev=0 --tags origin`
+git clone https://github.com/creationix/nvm.git ~/.nvm && cd ~/.nvm && git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" origin`
 ```
 
 To activate nvm, you need to source it from your shell:
@@ -106,7 +106,7 @@ export NVM_DIR="$HOME/.nvm"
 For manual upgrade with `git`, change to the `$NVM_DIR`, pull down the latest changes, and check out the latest version:
 
 ```sh
-cd "$NVM_DIR" && git fetch origin && git checkout `git describe --abbrev=0 --tags origin`
+cd "$NVM_DIR" && git fetch origin && git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" origin`
 ```
 
 After upgrading, don't forget to activate the new version:


### PR DESCRIPTION
Ensure `git describe` gives latest tag

I recently ran the upgrade instructions and I ended up with the version
I was already on. This happened because `git describe` describes a
commit using the most recent tag reachable from it. Since I already had
a tag checked out, it was describing the tag I had already checked out.

Thankfully, `git describe` accepts an optional commit-ish, which it will
use instead of what we have currently checked out. Testing this in my
terminal now gives me the latest tag on origin, which is what I am
interested in when updating to the latest version.

```
  ~/.nvm ❯❯❯ git describe --abbrev=0 --tags
  v0.30.1
  ~/.nvm ❯❯❯ git describe --abbrev=0 --tags origin
  v0.31.3
```

I also added it to the manual install instructions for consistency and
extra safety.

---

Ensure `git describe` only matches version tags

`git describe` will match the latest tags, regardless of what it looks
like. We can make this a little safer by adding a `--match` flag to
match tags that look like version tags. This allows the maintainers of
this repo to more safely add other types of tags if they so wish,
without causing people to install or upgrade to those versions.

---

Use subshells for installation and upgrade instructions

I recently upgraded my copy of nvm and I was disappointed to be dropped
in the .nvm directory at the end of it. I also didn't like having to
copy and paste two separate blocks of code into my terminal, because I
missed the second one the first time around and was left in a slightly
confusing state. So, I decided to make this easier by utilizing
subshells and moving all of the instructions into one code block in this
document. I think this will improve people's experience maintaining this
tool.