### PR TITLE
Document required git version

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,7 +81,7 @@ which should output 'nvm' if the installation was successful. Please note that `
 
 For manual install create a folder somewhere in your filesystem with the `nvm.sh` file inside it. I put mine in `~/.nvm`.
 
-Or if you have `git` installed:
+Or if you have `git` installed (requires git v1.5.5+):
 
 1. clone this repo
 1. check out the latest version
@@ -105,7 +105,7 @@ export NVM_DIR="$HOME/.nvm"
 
 ### Manual upgrade
 
-For manual upgrade with `git`:
+For manual upgrade with `git` (requires git v1.5.5+):
 
 1. change to the `$NVM_DIR`
 1. pull down the latest changes


### PR DESCRIPTION
git-describe was taught `--abbrev=0` in 1.5.0:

  https://github.com/git/git/blob/master/Documentation/RelNotes/1.5.0.txt

git-describe was taught `--match` in 1.5.5:

  https://github.com/git/git/blob/master/Documentation/RelNotes/1.5.5.txt

I don't see anything else potentially weird in here, so I think it is
safe to proclaim that the minimum git version required to run these
commands is 1.5.5.

Documenting this minimum version required here should help people debug
possible issues and help maintainers of this project understand the
impacts of modifying these commands in the future.