### PR TITLE
Unlock src build for node version greater than 1.0

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2086,11 +2086,6 @@ nvm() {
             nvm_err 'Installing iojs from source is not currently supported'
             return 105
             ;;
-          "$NVM_NODE_MERGED")
-            # nvm_install_merged_node_source "$VERSION" "$NVM_MAKE_JOBS" "$ADDITIONAL_PARAMETERS"
-            nvm_err 'Installing node v1.0 and greater from source is not currently supported'
-            return 106
-            ;;
           *)
             if nvm_install_node_source "$VERSION" "$NVM_MAKE_JOBS" "$ADDITIONAL_PARAMETERS"; then
               NVM_INSTALL_SUCCESS=true


### PR DESCRIPTION
Is there any reason to "block" / "lock" the feature of building binary from source for nodejs version greater than v1.0? It could also help nvm work on FreeBSD since there is no official binary builds for FreeBSD from nodejs.org, and it actually work on by environment, just need more tests.

cc #900 #1188 
