### PR TITLE
[Tests] add `shellcheck`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,14 @@ addons:
   apt_packages:
   - zsh
   - ksh
+cache:
+  directories:
+    - $HOME/.stack
 before_install:
   - $SHELL --version 2> /dev/null || dpkg -s $SHELL 2> /dev/null || which $SHELL
   - curl --version
   - wget --version
-  - if [ -n "${SHELLCHECK-}" ]; then echo "deb http://archive.ubuntu.com/ubuntu/ wily universe" | sudo tee -a /etc/apt/sources.list && sudo apt-get update -q && sudo apt-get install shellcheck -y && shellcheck --version ; fi
+  - if [ -n "${SHELLCHECK-}" ]; then sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442 && echo 'deb http://download.fpcomplete.com/ubuntu precise main' | sudo tee /etc/apt/sources.list.d/fpco.list && sudo apt-get update && sudo apt-get install stack bc -y && stack setup && stack install ShellCheck && shellcheck --version ; fi
 install:
   - (mkdir /tmp/urchin && cd /tmp/urchin && curl -s "$(curl -s https://registry.npmjs.com/urchin | grep -Eo '"tarball":\s*"[^"]+"' | tail -n 1 | awk -F\" '{ print $4 }')" -O && tar -x -f urchin*)
   - chmod +x /tmp/urchin/package/urchin

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,18 @@ before_install:
   - $SHELL --version 2> /dev/null || dpkg -s $SHELL 2> /dev/null || which $SHELL
   - curl --version
   - wget --version
+  - if [ -n "${SHELLCHECK-}" ]; then echo "deb http://archive.ubuntu.com/ubuntu/ wily universe" | sudo tee -a /etc/apt/sources.list && sudo apt-get update -q && sudo apt-get install shellcheck -y && shellcheck --version ; fi
 install:
   - (mkdir /tmp/urchin && cd /tmp/urchin && curl -s "$(curl -s https://registry.npmjs.com/urchin | grep -Eo '"tarball":\s*"[^"]+"' | tail -n 1 | awk -F\" '{ print $4 }')" -O && tar -x -f urchin*)
   - chmod +x /tmp/urchin/package/urchin
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
 script:
   - export PATH=$(echo $PATH | sed 's/::/:/')
-  - NVM_DIR=$TRAVIS_BUILD_DIR make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin/package/urchin test-$SHELL
+  - export NVM_DIR="${TRAVIS_BUILD_DIR}"
+  - if [ -n "${SHELLCHECK-}" ]; then shellcheck -s bash nvm.sh && shellcheck -s sh nvm.sh && shellcheck -s dash nvm.sh && shellcheck -s ksh nvm.sh && shellcheck -s bash install.sh ; fi
+  - if [ -z "${SHELLCHECK-}" ]; then make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin/package/urchin test-$SHELL ; fi
 env:
+  - SHELLCHECK=true
   - SHELL=bash TEST_SUITE=install_script
   - SHELL=sh TEST_SUITE=fast
   - SHELL=dash TEST_SUITE=fast

--- a/install.sh
+++ b/install.sh
@@ -240,24 +240,24 @@ nvm_check_global_modules() {
 }
 
 nvm_do_install() {
-  if [ -z "$METHOD" ]; then
+  if [ -z "${METHOD}" ]; then
     # Autodetect install method
-    if nvm_has "git"; then
+    if nvm_has git; then
       install_nvm_from_git
-    elif nvm_has "nvm_download"; then
+    elif nvm_has nvm_download; then
       install_nvm_as_script
     else
-      echo >&2 "You need git, curl, or wget to install nvm"
+      echo >&2 'You need git, curl, or wget to install nvm'
       exit 1
     fi
-  elif [ "~$METHOD" = "~git" ]; then
-    if ! nvm_has "git"; then
+  elif [ "${METHOD}" = 'git' ]; then
+    if ! nvm_has git; then
       echo >&2 "You need git to install nvm"
       exit 1
     fi
     install_nvm_from_git
-  elif [ "~$METHOD" = "~script" ]; then
-    if ! nvm_has "nvm_download"; then
+  elif [ "${METHOD}" = 'script' ]; then
+    if ! nvm_has nvm_download; then
       echo >&2 "You need curl or wget to install nvm"
       exit 1
     fi


### PR DESCRIPTION
Run `shellcheck` on tests to ensure we're not following bad practices.

Note that once this build completes, successive shellcheck builds will be much faster due to travis caching.