### PR TITLE
Ensure script only runs in users HOME directory

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -97,6 +97,9 @@ nvm_print_npm_version() {
   fi
 }
 
+# Ensure this only runs in the users $HOME directory
+cd "$HOME"
+
 # Make zsh glob matching behave same as bash
 # This fixes the "zsh: no matches found" errors
 if [ -z "${NVM_CD_FLAGS-}" ]; then


### PR DESCRIPTION
I had a minor issue with NVM after installing on an Ubuntu Server.
The issue was caused by the fact the `nvm.sh` script tries to perform actions that require permissions in the current working directory (an unknown directory at the time the users `.bashrc` is sourced.
Say I have a user `bob` with NVM and node installed.
If I log on to my Ubuntu instance as user `root` and am in the root home directory `/root` then do `su bob` to switch to the `bob` user, bob's `~/.bashrc` is sourced and NVM sources `"$NVM_DIR/nvm.sh"`. In most cases this isn't a problem, but in the example I provided, as I was in the `/root` directory when I switched to user `bob`, the current directory is maintained which is `/root` and `bob` doesn't have read/write access there so when the NVM script is sourced it fails with permission errors. In theory, nothing sourced in the `.bashrc` should rely on the unkown current working directory and to fix NVM, all that's needed is to ensure the script runs in a location where it has access. As NVM is sourced by a users `.bashrc` I think it makes to sense that it runs in the users home directory, hence the change I'm proposing.
