### PR TITLE
Postpone bootstrap to reduce shell startup time

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -289,11 +289,8 @@ nvm_do_install() {
 
   SOURCE_STR="\nexport NVM_DIR=\"$INSTALL_DIR\""
   SOURCE_STR="$SOURCE_STR\nnvm() {\n  echo Loading nvm for first use in this shell >/dev/stderr"
-  SOURCE_STR="$SOURCE_STR\n  [ -s \"\$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" # This loads nvm"
+  SOURCE_STR="$SOURCE_STR\n  [ -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$NVM_DIR/nvm.sh\" # This loads nvm"
   SOURCE_STR="$SOURCE_STR\n  nvm \"\$@\"\n}"
-  echo $SOURCE_STR
-}
-
 
   if [ -z "${NVM_PROFILE-}" ] ; then
     echo "=> Profile not found. Tried ${NVM_PROFILE} (as defined in \$PROFILE), ~/.bashrc, ~/.bash_profile, ~/.zshrc, and ~/.profile."

--- a/install.sh
+++ b/install.sh
@@ -287,7 +287,13 @@ nvm_do_install() {
   local INSTALL_DIR
   INSTALL_DIR="$(nvm_install_dir)"
 
-  SOURCE_STR="\nexport NVM_DIR=\"$INSTALL_DIR\"\n[ -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$NVM_DIR/nvm.sh\"  # This loads nvm\n"
+  SOURCE_STR="\nexport NVM_DIR=\"$INSTALL_DIR\""
+  SOURCE_STR="$SOURCE_STR\nnvm() {\n  echo Loading nvm for first use in this shell >/dev/stderr"
+  SOURCE_STR="$SOURCE_STR\n  [ -s \"\$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" # This loads nvm"
+  SOURCE_STR="$SOURCE_STR\n  nvm \"\$@\"\n}"
+  echo $SOURCE_STR
+}
+
 
   if [ -z "${NVM_PROFILE-}" ] ; then
     echo "=> Profile not found. Tried ${NVM_PROFILE} (as defined in \$PROFILE), ~/.bashrc, ~/.bash_profile, ~/.zshrc, and ~/.profile."


### PR DESCRIPTION
Change the shell initialization of nvm, so that the bootstrap time
of sourcing nvm.sh is done when nvm is used for the first time in
the shell session. This makes a difference of almost half a second
on my machine on each shell startup.

Concretely, `nvm` is a function which sources `$NVM_DIR/nvm.sh`,
runs the newly created `nvm` function with the given command line
arguments, and exits.

On subsequent invocations of the `nvm` command, the freshly loaded
nvm function from `$NVM_DIR/nvm.sh` will be used. For the user, 
the change in this commit is transparent.

The following snippet will be added to the shell's start-up file
(assuming the default installation directory):

``` sh
export NVM_DIR="$HOME/.nvm"
nvm() {
  echo Loading nvm for first use in this shell >/dev/stderr
  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
  nvm "$@"
}
```