### PR TITLE
Removes fin from the readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,6 @@ Note: `nvm` does not support Windows (see [#284](https://github.com/creationix/n
 Note: `nvm` does not support [Fish] either (see [#303](https://github.com/creationix/nvm/issues/303)). Alternatives exist, which are neither supported nor developed by us:
  - [bass](https://github.com/edc/bass) allows you to use utilities written for Bash in fish shell
  - [fast-nvm-fish](https://github.com/brigand/fast-nvm-fish) only works with version numbers (not aliases) but doesn't significantly slow your shell startup
- - [fin](https://github.com/fisherman/fin) is a pure fish node version manager for fish shell
  - [plugin-nvm](https://github.com/derekstavis/plugin-nvm) plugin for [Oh My Fish](https://github.com/oh-my-fish/oh-my-fish), which makes nvm and its completions available in fish shell
 
 


### PR DESCRIPTION
If you go to the [fin repo](https://github.com/fisherman/fin) you'll see that it isn't a node version manager, but simply a plugin manager for Fish. Seems out of scope for the readme, and there are other plugin solutions for fish as well. I suggest removing the reference.