### PR TITLE
Consolidate APT packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ addons:
     packages:
       - gcc-4.8
       - g++-4.8
-  apt_packages:
-    - zsh
-    - ksh
+      - zsh
+      - ksh
 cache:
   directories:
     - $HOME/.stack


### PR DESCRIPTION
Consolidate APT packages definition into one place, so that the folding is displayed correctly.