### PR TITLE
speed up when change directory in zsh

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -316,9 +316,16 @@ Put this into your `$HOME/.zshrc` to call `nvm use` automatically whenever you e
 # place this after nvm initialization!
 autoload -U add-zsh-hook
 load-nvmrc() {
-  if [[ -f .nvmrc && -r .nvmrc ]]; then
-    nvm use
-  elif [[ $(nvm version) != $(nvm version default)  ]]; then
+  local node_version="$(nvm version)"
+  local nvmrc_path="$(nvm_find_nvmrc)"
+
+  if [ -n "$nvmrc_path" ]; then
+    local nvmrc_node_version=$(nvm version "$(cat "${nvmrc_path}")")
+
+    if [ "$nvmrc_node_version" != "N/A" ] && [ "$nvmrc_node_version" != "$node_version" ]; then
+      nvm use 
+    fi
+  elif [ "$node_version" != "$(nvm version default)" ]; then
     echo "Reverting to nvm default version"
     nvm use default
   fi


### PR DESCRIPTION
This pull request resolve two questions:
1. For example, my project path is /home/user/work/nvm, in this project directory there is a .nvmrc file with v4.4.7, and my nvm default is v6.7.0。if i enter /home/user/work/nvm, nvm change node to v4.4.7 which is reasonable. but if i enter /home/user/work/nvm/public, nvm use default invoked and now the node become v6.7.0. use the new code, when enter /home/user/work/nvm/public, nvm not only check if .nvmrc exist in this directory, bus also check parents directory which can solve my problem.
2. In current version of nvm, if my node version is v6.7.0 and the directory i enterd have .nvmrc file with content of v6.7.0, nvm also invoke nvm use and cost some time, it's meanless.