### PR TITLE
Revert "Also run git gc after nvm upgraded"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,10 +74,6 @@ install_nvm_from_git() {
       echo >&2 "Failed to update nvm, run 'git fetch' in $INSTALL_DIR yourself."
       exit 1
     }
-    echo "=> Compressing and cleaning up git repository"
-    if ! command git --git-dir="$INSTALL_DIR"/.git --work-tree="$INSTALL_DIR" gc --aggressive --prune=now ; then
-      echo >&2 "Your version of git is out of date. Please update it!"
-    fi
   else
     # Cloning to $INSTALL_DIR
     echo "=> Downloading nvm from git to '$INSTALL_DIR'"


### PR DESCRIPTION
This reverts commit ce7f6d6e5287fade16c41c7a18dd3a2043928efe.

ce7f6d6e5287fade16c41c7a18dd3a2043928efe could be a mistake, as we'll always execute the gc command at the end of `install_nvm_from_git()`, this commit should be reverted, sorry for my mistake.