### PR TITLE
[Tests] Move shellcheck to CircleCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ install:
   - chmod +x /tmp/urchin/package/urchin
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
 script:
-  - if [ -n "${SHELLCHECK-}" ]; then shellcheck -s bash nvm.sh && shellcheck -s sh nvm.sh && shellcheck -s dash nvm.sh && shellcheck -s ksh nvm.sh && shellcheck -s bash install.sh ; fi
-  - if [ -z "${SHELLCHECK-}" ]; then make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin/package/urchin test-$SHELL ; fi
+  - make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin/package/urchin test-$SHELL
 env:
   global:
     - CXX=g++-4.8
@@ -42,7 +41,6 @@ env:
     - PATH=$(echo $PATH | sed 's/::/:/')
     - NVM_DIR="${TRAVIS_BUILD_DIR}"
   matrix:
-    - SHELLCHECK=true
     - SHELL=bash TEST_SUITE=install_script
     - SHELL=sh TEST_SUITE=fast
     - SHELL=dash TEST_SUITE=fast

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,7 @@
-# Node Version Manager [![Build Status](https://travis-ci.org/creationix/nvm.svg?branch=master)][3] ![nvm version](https://img.shields.io/badge/version-v0.32.1-yellow.svg)
+# Node Version Manager
+[![Build Status](https://travis-ci.org/creationix/nvm.svg?branch=master)][3]
+[![Circle CI Build Status](https://img.shields.io/circleci/project/creationix/nvm/master.svg)][4]
+![nvm version](https://img.shields.io/badge/version-v0.32.1-yellow.svg)
 
 ## Table of Contents
 
@@ -468,5 +471,6 @@ If setting the `default` alias does not establish the node version in new shells
 [1]: https://github.com/creationix/nvm.git
 [2]: https://github.com/creationix/nvm/blob/v0.32.1/install.sh
 [3]: https://travis-ci.org/creationix/nvm
+[4]: https://circleci.com/gh/creationix/nvm
 [Urchin]: https://github.com/scraperwiki/urchin
 [Fish]: http://fishshell.com

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+dependencies:
+  override:
+    - sudo ln -sf /home/ubuntu/.local/bin/shellcheck /usr/bin/shellcheck
+    - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442 && echo 'deb http://download.fpcomplete.com/ubuntu precise main' | sudo tee /etc/apt/sources.list.d/fpco.list && sudo apt-get update && sudo apt-get install stack bc -y && stack setup && stack install ShellCheck && shellcheck --version
+  cache_directories:
+    - "~/.stack"
+
+test:
+  override:
+    - shellcheck -s bash nvm.sh && shellcheck -s sh nvm.sh && shellcheck -s dash nvm.sh && shellcheck -s ksh nvm.sh && shellcheck -s bash install.sh


### PR DESCRIPTION
Currently, the testing process on TraivisCI is so slow because we have a lot of tests, by moving shellcheck to CircleCI, we can speed up the process without a doubt, and the syntax/coding style check won't be hang by the other tests.

This PR only help move shellcheck test to CircleCI config, you'll need to move to https://circleci.com to enable CircleCI for this project.

Examples:
https://circleci.com/gh/PeterDaveHello/nvm/16
https://circleci.com/gh/PeterDaveHello/nvm/18