### PR TITLE
Optimize package install process on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,16 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - fpcomplete-precise
+      - llvm-toolchain-precise
+      - llvm-toolchain-precise-3.8
     packages:
       - gcc-4.8
       - g++-4.8
+      - clang-3.8
+      - lldb-3.8
+      - stack
+      - bc
       - zsh
       - ksh
 cache:
@@ -19,8 +26,8 @@ before_install:
   - wget --version
   - clang --version
   - clang++ --version
-  - if [ -n "${SHELLCHECK-}" ]; then sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 575159689BEFB442 && echo 'deb http://download.fpcomplete.com/ubuntu precise main' | sudo tee /etc/apt/sources.list.d/fpco.list && sudo apt-get update && sudo apt-get install stack bc -y && stack setup && stack install ShellCheck && shellcheck --version ; fi
-  - if [ -z "${SHELLCHECK-}" ]; then wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && echo -e "deb http://apt.llvm.org/precise/ llvm-toolchain-precise main\ndeb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.8 main" | sudo tee /etc/apt/sources.list.d/clang.list && sudo apt-get update && sudo apt-get install clang-3.8 lldb-3.8 -y --force-yes && sudo ln -sf /usr/bin/clang-3.8 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-3.8 /usr/bin/clang++ && clang --version ; fi
+  - if [ -n "${SHELLCHECK-}" ]; then stack setup && stack install ShellCheck && shellcheck --version ; fi
+  - if [ -z "${SHELLCHECK-}" ]; then sudo ln -sf /usr/bin/clang-3.8 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-3.8 /usr/bin/clang++ && clang --version ; fi
 install:
   - (mkdir /tmp/urchin && cd /tmp/urchin && curl -s "$(curl -s https://registry.npmjs.com/urchin | grep -Eo '"tarball":\s*"[^"]+"' | tail -n 1 | awk -F\" '{ print $4 }')" -O && tar -x -f urchin*)
   - chmod +x /tmp/urchin/package/urchin


### PR DESCRIPTION
 - Use Travis CI apt addon source whitelist to load apt source
 - Use Travis CI apt addon to install additional packages
  
This can make `.travis.yml` more structured and cleaner, prevent duplicating apt package list update and dependencies calculation which means it can speed up the CI build.
