### PR TITLE
[Tests] Remove not working clang part until we refactor the workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,9 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise
-      - llvm-toolchain-precise-3.8
     packages:
       - gcc-4.8
       - g++-4.8
-      - clang-3.8
-      - lldb-3.8
       - cabal-install
       - ghc
       - zsh
@@ -23,10 +19,7 @@ before_install:
   - $SHELL --version 2> /dev/null || dpkg -s $SHELL 2> /dev/null || which $SHELL
   - curl --version
   - wget --version
-  - clang --version
-  - clang++ --version
   - if [ -n "${SHELLCHECK-}" ]; then cabal update && cabal install transformers-0.4.3.0 ShellCheck && shellcheck --version ; fi
-  - if [ -z "${SHELLCHECK-}" ]; then sudo ln -sf /usr/bin/clang-3.8 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-3.8 /usr/bin/clang++ && clang --version ; fi
 install:
   - (mkdir /tmp/urchin && cd /tmp/urchin && curl -s "$(curl -s https://registry.npmjs.com/urchin | grep -Eo '"tarball":\s*"[^"]+"' | tail -n 1 | awk -F\" '{ print $4 }')" -O && tar -x -f urchin*)
   - chmod +x /tmp/urchin/package/urchin


### PR DESCRIPTION
The works in #1310 are huge and need time, since the current clang in Travis CI is not working yet, should remove this part until we refactor the testing work flow.