### PR TITLE
[Tests] also cache $HOME/.ghc for cabal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
       - ksh
 cache:
   directories:
+    - $HOME/.ghc
     - $HOME/.cabal
     - $TRAVIS_BUILD_DIR/.cache
 before_install:


### PR DESCRIPTION
Just found that only caching `$HOME/.cabal` is not enough, also need `$HOME/.ghc`

See the result at:
https://travis-ci.org/PeterDaveHelloKitchen/nvm/builds/178875370