### PR TITLE
[Fix] install from src should do "nvm use" before npm detection

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1926,7 +1926,7 @@ nvm_install_source() {
     command rm -f "${VERSION_PATH}" 2>/dev/null && \
     $make -j "${NVM_MAKE_JOBS}" ${MAKE_CXX-} install
   ); then
-    if ! nvm_has "npm" ; then
+    if (nvm use "${VERSION}" && ! nvm_has "npm") ; then
       nvm_echo 'Installing npm...'
       if nvm_version_greater 0.2.0 "$VERSION"; then
         nvm_err 'npm requires node v0.2.3 or higher'


### PR DESCRIPTION
The origin logic didn't noticed that the new installed nodejs will not be in the PATH, so if you don't have any installed npm, no matter if you installed nodejs succeed or failed this time, you'll never detect it, so should try to activate the version and then do the npm detection.