### PR TITLE
[Docs] Link version badge to the release page

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# Node Version Manager [![Build Status](https://travis-ci.org/creationix/nvm.svg?branch=master)][3] ![nvm version](https://img.shields.io/badge/version-v0.32.1-yellow.svg)
+# Node Version Manager [![Build Status](https://travis-ci.org/creationix/nvm.svg?branch=master)][3] [![nvm version](https://img.shields.io/badge/version-v0.32.1-yellow.svg)][4]
 
 ## Table of Contents
 
@@ -468,5 +468,6 @@ If setting the `default` alias does not establish the node version in new shells
 [1]: https://github.com/creationix/nvm.git
 [2]: https://github.com/creationix/nvm/blob/v0.32.1/install.sh
 [3]: https://travis-ci.org/creationix/nvm
+[4]: https://github.com/creationix/nvm/releases/tag/v0.32.1
 [Urchin]: https://github.com/scraperwiki/urchin
 [Fish]: http://fishshell.com


### PR DESCRIPTION
The origin badge will link to the GitHub cached badge image which is meaningless to us, link to the release page will be much more meaningful.

Tested with `make release`