### PR TITLE
Post install hook

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2464,6 +2464,10 @@ nvm() {
           && [ "_$REINSTALL_PACKAGES_FROM" != "_N/A" ]; then
           nvm reinstall-packages "$REINSTALL_PACKAGES_FROM"
         fi
+        if [ ! -z "${NVM_POST_INSTALL-}" ]; then
+          nvm_echo 'Running post install hook.'
+          ($NVM_POST_INSTALL)
+        fi
       fi
       return $?
     ;;


### PR DESCRIPTION
- `NVM_POST_INSTALL` env variable is executed after `nvm install` if it is set
- A fairly unopinionated change that would be a nice way to allow global node modules to be installed after a new node version is installed, as discussed in https://github.com/creationix/nvm/issues/977

## Using the hook install global npm modules
Just add the `NVM_POST_INSTALL` variable to `.bash_profile`, installing global modules that are used frequently.

```
export NVM_DIR="$HOME/.nvm"
export NVM_POST_INSTALL="npm install -g serve webpack standard"
[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
```