### PR TITLE
bash_completion fixes

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2,6 +2,10 @@
 
 # bash completion for Node Version Manager (NVM)
 
+if ! nvm &> /dev/null; then
+    return
+fi
+
 __nvm_generate_completion()
 {
   declare current_word

--- a/install.sh
+++ b/install.sh
@@ -353,7 +353,7 @@ nvm_do_install() {
   echo "=> Close and reopen your terminal to start using nvm or run the following to use it now:"
   command printf "${SOURCE_STR}"
   if ${BASH_OR_ZSH} ; then
-    command printf " && ${COMPLETION_STR}"
+    command printf "${COMPLETION_STR}"
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,19 @@ nvm_latest_version() {
   echo "v0.33.1"
 }
 
+nvm_profile_is_bash_or_zsh() {
+    local TEST_PROFILE
+    TEST_PROFILE="${1-}"
+    case "${TEST_PROFILE-}" in
+      *"/.bashrc" | *"/.bash_profile" | *"/.zshrc")
+          return
+      ;;
+      *)
+          return 1
+      ;;
+    esac
+}
+
 #
 # Outputs the location to NVM depending on:
 # * The availability of $NVM_SOURCE
@@ -305,11 +318,9 @@ nvm_do_install() {
     echo "=> Append the following lines to the correct file yourself:"
     command printf "${SOURCE_STR}"
   else
-    case "${NVM_PROFILE-}" in
-      ".bashrc" | ".bash_profile" | ".zshrc")
-        BASH_OR_ZSH=true
-      ;;
-    esac
+    if nvm_profile_is_bash_or_zsh "${NVM_PROFILE-}"; then
+      BASH_OR_ZSH=true
+    fi
     if ! command grep -qc '/nvm.sh' "$NVM_PROFILE"; then
       echo "=> Appending nvm source string to $NVM_PROFILE"
       command printf "${SOURCE_STR}" >> "$NVM_PROFILE"

--- a/test/install_script/nvm_profile_is_bash_or_zsh
+++ b/test/install_script/nvm_profile_is_bash_or_zsh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+NVM_ENV=testing \. ../../install.sh
+
+#nvm_profile_is_bash_or_zsh is available
+type nvm_profile_is_bash_or_zsh > /dev/null 2>&1 || die 'nvm_profile_is_bash_or_zsh is not available'
+nvm_profile_is_bash_or_zsh "/home/nvm/.bashrc"   || die '/home/nvm/.bashrc is bash profile'
+nvm_profile_is_bash_or_zsh "/home/nvm/.bash_profile"   || die '/home/nvm/.bash_profile is bash profile'
+nvm_profile_is_bash_or_zsh "/home/nvm/.zshrc"    || die '/home/nvm/.zshrc is zsh profile'
+if nvm_profile_is_bash_or_zsh "/home/nvm/.bash"; then die '/home/nvm/.bash is not bash nor zsh profile'; fi
+if nvm_profile_is_bash_or_zsh "/home/nvm/.zsh" ; then die '/home/nvm/.zsh is not bash nor zsh profile'; fi


### PR DESCRIPTION
1. Since `NVM_PROFILE` will be a full path, the detection was not working properly without `*/` prefix.
2. The origin bash_completion source prompt in installation was:
```sh
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
```
Which will cause this error if you don't manually remove the comment:
```
-bash: x: line 2: syntax error near unexpected token `&&'
-bash: x: line 2: ` && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion'
```
Which is inconvenient, so I removed the ` &&` prefix, and let the `bash_completion` to detect if `nvm` loaded.

3. bash_completion didn't detect if `nvm` already loaded or not, so it'll work even if `nvm` is not loaded, now it'll detect if `nvm` loaded yet.