### PR TITLE
Update README.markdown for latest instructions to use with `fish` shell

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,10 +31,10 @@ First you'll need to make sure your system has a c++ compiler. For OS X, Xcode w
  - [nvm-windows](https://github.com/coreybutler/nvm-windows)
  - [nodist](https://github.com/marcelklehr/nodist)
 
-**Note:** `nvm` does not support [Fish] either (see [#303](https://github.com/creationix/nvm/issues/303)). Alternatives exist, which are neither supported nor developed by us:
- - [bass](https://github.com/edc/bass) allows you to use utilities written for Bash in fish shell
- - [fast-nvm-fish](https://github.com/brigand/fast-nvm-fish) only works with version numbers (not aliases) but doesn't significantly slow your shell startup
- - [plugin-nvm](https://github.com/derekstavis/plugin-nvm) plugin for [Oh My Fish](https://github.com/oh-my-fish/oh-my-fish), which makes nvm and its completions available in fish shell
+**Note:** `nvm` does not support [Fish] either (see [#303](https://github.com/creationix/nvm/issues/303)). Alternatives exist, but are not supported nor developed by us:
+ - [bass](https://github.com/edc/bass) allows you to use utilities written for Bash in fish shell (recommended)
+ - ~~[fast-nvm-fish](https://github.com/brigand/fast-nvm-fish) only works with version numbers (not aliases) but doesn't significantly slow your shell startup~~
+ - ~~[plugin-nvm](https://github.com/derekstavis/plugin-nvm) plugin for [Oh My Fish](https://github.com/oh-my-fish/oh-my-fish), which makes nvm and its completions available in fish shell~~
 
 
 


### PR DESCRIPTION
Bass seems to be only non-buggy solution right now. Clean, and just works.