### PR TITLE
Don't hardcode version in the install curl/wget instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -67,13 +67,13 @@ Homebrew installation is not supported. If you have issues with homebrew-install
 To install or update nvm, you can use the [install script][2] using cURL:
 
 ```sh
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
+curl -o- https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
 ```
 
 or Wget:
 
 ```sh
-wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
+wget -qO- https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
 ```
 
 <sub>The script clones the nvm repository to `~/.nvm` and adds the source line to your profile (`~/.bash_profile`, `~/.zshrc`, `~/.profile`, or `~/.bashrc`).</sub>


### PR DESCRIPTION
changed to use master in path to install.sh instead a version number so that this command can be generic to get the latest master version of the install script