### PR TITLE
[Fix] declare MANPATH if and only if it's not set

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2661,8 +2661,8 @@ nvm() {
       # Prepend current version
       PATH="$(nvm_prepend_path "$PATH" "$NVM_VERSION_DIR/bin")"
       if nvm_has manpath; then
-        local MANPATH
         if [ -z "$MANPATH" ]; then
+          local MANPATH
           MANPATH=$(manpath)
         fi
         # Strip other version from MANPATH


### PR DESCRIPTION
By manpath's man page in Ubuntu 16.04:

> If $MANPATH is set, manpath will simply display its contents and issue
> a warning.

By fa22d712ff7367fc0ecc87bbe8801d77303068e3 for #1413, `nvm` now will
declare the "MANPATH" variable, no matter if it's set or not, so in the
situation that $MANPATH is set, you'll get the warning:

> manpath: warning: $MANPATH set, ignoring /etc/manpath.config