### PR TITLE
[Docs] Update Installation section

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@
 
 ## Installation
 
-First you'll need to make sure your system has a c++ compiler. For OS X, Xcode will work, for Ubuntu, the `build-essential` and `libssl-dev` packages work.
+If you're running a system without prepackaged binary available, which means you're going to install nodejs or io.js from its source code, you need to make sure your system has a c++ compiler. For OS X, Xcode will work, for Debian/Ubuntu based GNU/Linux, the `build-essential` and `libssl-dev` packages work.
 
 **Note:** `nvm` does not support Windows (see [#284](https://github.com/creationix/nvm/issues/284)). Two alternatives exist, which are neither supported nor developed by us:
  - [nvm-windows](https://github.com/coreybutler/nvm-windows)
@@ -41,8 +41,6 @@ First you'll need to make sure your system has a c++ compiler. For OS X, Xcode w
  - [bass](https://github.com/edc/bass) allows you to use utilities written for Bash in fish shell
  - [fast-nvm-fish](https://github.com/brigand/fast-nvm-fish) only works with version numbers (not aliases) but doesn't significantly slow your shell startup
  - [plugin-nvm](https://github.com/derekstavis/plugin-nvm) plugin for [Oh My Fish](https://github.com/oh-my-fish/oh-my-fish), which makes nvm and its completions available in fish shell
-
-
 
 **Note:** We still have some problems with FreeBSD, because there is no official pre-built binary for FreeBSD, and building from source may need [patches](https://www.freshports.org/www/node/files/patch-deps_v8_src_base_platform_platform-posix.cc); see the issue ticket:
  - [[#900] [Bug] nodejs on FreeBSD need to be patched ](https://github.com/creationix/nvm/issues/900)


### PR DESCRIPTION
1. If we are not going to install nodejs or io.js from source, we may
not need to have c++ compiler or libssl-dev package
2. the `build-essential` and `libssl-dev` packages should work on all
the Debian and Ubuntu based GNU/Linux distros
3. Remove useless blank lines