### PR TITLE
[New] Enable curl auto compression/decompression

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -60,6 +60,8 @@ Homebrew installation is not supported. If you have issues with homebrew-install
 
 **Note:** Git versions before v1.7 may face a problem of cloning nvm source from GitHub via https protocol, and there is also different behavior of git before v1.6, so the minimum required git version is v1.7.0 and we recommend v1.7.9.5 as it's the default version of the widely used Ubuntu 12.04 LTS. If you are interested in the problem we mentioned here, please refer to GitHub's [HTTPS cloning errors](https://help.github.com/articles/https-cloning-errors/) article.
 
+**Note:** `nvm` uses `curl` with the `--compressed` option which was introduced on September 3rd, 2002([curl/curl@64bbe9d](https://github.com/curl/curl/commit/64bbe9dfafc6693a96b742f3133c636385835a19)). It's unlikely, but if you have `curl` compiled without that feature, `nvm` may not be able to install or list remote `node` versions. Please file an issue if your `curl` does not work with `--compressed` (and you didn't explicitly compile `curl` to not have compression support).
+
 ### Install script
 
 To install or update nvm, you can use the [install script][2] using cURL:

--- a/install.sh
+++ b/install.sh
@@ -62,11 +62,12 @@ nvm_node_version() {
 
 nvm_download() {
   if nvm_has "curl"; then
-    curl -q "$@"
+    curl --compressed -q "$@"
   elif nvm_has "wget"; then
     # Emulate curl with wget
     ARGS=$(echo "$*" | command sed -e 's/--progress-bar /--progress=bar /' \
                            -e 's/-L //' \
+                           -e 's/--compressed //' \
                            -e 's/-I /--server-response /' \
                            -e 's/-s /-q /' \
                            -e 's/-o /-O /' \

--- a/nvm.sh
+++ b/nvm.sh
@@ -60,7 +60,7 @@ nvm_has_colors() {
 nvm_get_latest() {
   local NVM_LATEST_URL
   if nvm_has "curl"; then
-    NVM_LATEST_URL="$(curl -q -w "%{url_effective}\n" -L -s -S http://latest.nvm.sh -o /dev/null)"
+    NVM_LATEST_URL="$(curl --compressed -q -w "%{url_effective}\n" -L -s -S http://latest.nvm.sh -o /dev/null)"
   elif nvm_has "wget"; then
     NVM_LATEST_URL="$(wget http://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
   else
@@ -76,10 +76,11 @@ nvm_get_latest() {
 
 nvm_download() {
   if nvm_has "curl"; then
-    curl -q "$@"
+    curl --compressed -q "$@"
   elif nvm_has "wget"; then
     # Emulate curl with wget
     ARGS=$(nvm_echo "$@" | command sed -e 's/--progress-bar /--progress=bar /' \
+                           -e 's/--compressed //' \
                            -e 's/-L //' \
                            -e 's/-I /--server-response /' \
                            -e 's/-s /-q /' \

--- a/test/fast/Unit tests/nvm_curl_libz_support
+++ b/test/fast/Unit tests/nvm_curl_libz_support
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+cleanup() {
+  unset -f curl
+}
+
+die() { cleanup; echo "$@" ; exit 1; }
+
+\. ../../../nvm.sh
+
+curl() {
+    # curl with libz feature
+    if [ $# -ne 1 ] || [ "$1" != "-V" ]; then
+        die "This fake curl only takes one parameter -V"
+    fi
+    echo "
+curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 GnuTLS/3.4.10 zlib/1.2.8 libidn/1.32 librtmp/2.3
+Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smb smbs smtp smtps telnet tftp
+Features: AsynchDNS IDN IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz TLS-SRP UnixSockets"
+}
+
+nvm_curl_libz_support || die "nvm_curl_libz_support should return 0"
+
+unset -f curl
+
+curl() {
+    # curl without libz feature
+    if [ "$#" -ne 1 ] || [ "$1" != "-V" ]; then
+        die "This fake curl only takes one parameter -V"
+    fi
+    echo "
+curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 GnuTLS/3.4.10 zlib/1.2.8 libidn/1.32 librtmp/2.32
+Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smb smbs smtp smtps telnet tftp
+Features: AsynchDNS IDN IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL TLS-SRP UnixSockets"
+}
+
+! nvm_curl_libz_support || die "nvm_curl_libz_support should return 1"
+
+unset -f curl

--- a/test/slow/nvm_get_latest/nvm_get_latest
+++ b/test/slow/nvm_get_latest/nvm_get_latest
@@ -10,7 +10,7 @@ cleanup() {
 
 EXPECTED_VERSION="v12.3.456"
 URL="https://github.com/creationix/nvm/releases/tag/$EXPECTED_VERSION"
-EXPECTED_CURL_ARGS="-q -w %{url_effective}\n -L -s -S http://latest.nvm.sh -o /dev/null"
+EXPECTED_CURL_ARGS="--compressed -q -w %{url_effective}\n -L -s -S http://latest.nvm.sh -o /dev/null"
 EXPECTED_WGET_ARGS="http://latest.nvm.sh --server-response -O /dev/null"
 
 curl() {

--- a/test/slow/nvm_get_latest/nvm_get_latest
+++ b/test/slow/nvm_get_latest/nvm_get_latest
@@ -14,7 +14,12 @@ EXPECTED_CURL_ARGS="--compressed -q -w %{url_effective}\n -L -s -S http://latest
 EXPECTED_WGET_ARGS="http://latest.nvm.sh --server-response -O /dev/null"
 
 curl() {
-  if [ "_$*" != "_$EXPECTED_CURL_ARGS" ]; then
+  if [ $# -eq 1 ] && [ "$1" = "-V" ]; then
+    echo "
+curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 GnuTLS/3.4.10 zlib/1.2.8 libidn/1.32 librtmp/2.3
+Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smb smbs smtp smtps telnet tftp
+Features: AsynchDNS IDN IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz TLS-SRP UnixSockets"
+  elif [ "_$*" != "_$EXPECTED_CURL_ARGS" ]; then
     echo >&2 "expected args ($EXPECTED_CURL_ARGS), got ($*)"
     return 1
   else


### PR DESCRIPTION
Enable `--compressed` parameter on curl to automatically enable
compression on request content by sending coressponding header, if the
server side supports compression format like deflate or gzip, curl will
also decompress the content automatically, so there is no additional
works need to done manually on client side, but just enjoy the benifits
of bandwidth and time saving!

Take https://nodejs.org/dist/index.tab as an example which is last
modified on Tue, 14 Mar 2017 22:41:05 GMT, the compressed transmission
only take 4829 bytes howevet the not compressed on taks 48000 bytes,
which is about 10 times larger!

This feature can be traced back to Sep 3 2002, in curl commit:
 - https://github.com/curl/curl/commit/64bbe9dfafc6693a96b742f3133c636385835a19

So should be supported on various versions widely.
(even on Ubuntu 08.04, just tested!)