### PR TITLE
[Tests] Add retry on urchin setup which has no built in retry feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - if [ -n "${SHELLCHECK-}" ]; then cabal update && cabal install transformers-0.4.3.0 ShellCheck && shellcheck --version ; fi
   - if [ -n "${DOCTOCCHECK-}" ]; then nvm install node && npm install -g doctoc && type doctoc ; fi
 install:
-  - (mkdir /tmp/urchin && cd /tmp/urchin && curl -s "$(curl -s https://registry.npmjs.com/urchin | grep -Eo '"tarball":\s*"[^"]+"' | tail -n 1 | awk -F\" '{ print $4 }')" -O && tar -x -f urchin*)
+  - (travis_retry mkdir /tmp/urchin && cd /tmp/urchin && curl -s "$(curl -s https://registry.npmjs.com/urchin | grep -Eo '"tarball":\s*"[^"]+"' | tail -n 1 | awk -F\" '{ print $4 }')" -O && tar -x -f urchin*)
   - chmod +x /tmp/urchin/package/urchin
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
 script:


### PR DESCRIPTION
Unlike other built in functions like git fetch or apt-get dependencies,
manual installations won't have retry by default, enabling retry could
help reduce the impact of network issues and furthur prevent getting
build error like Job #1956.21:
- https://travis-ci.org/creationix/nvm/jobs/212640007

Ref:
- https://docs.travis-ci.com/user/common-build-problems/