### PR TITLE
[Tests] Move to Ubuntu 14.04 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: generic
+dist: trusty
 sudo: required
 addons:
   apt:


### PR DESCRIPTION
Since Ubuntu 12.04 is pretty old now, it's also going to EOL next month,
maybe we can just move on Ubuntu 14.04 first.