### PR TITLE
[Tests] Remove ppa source since we migrated to Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: trusty
 sudo: required
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
       - gcc-4.8
       - g++-4.8


### PR DESCRIPTION
Though we can't drop add-on but Ubuntu 14.04 doesn't need to install gcc & g++ v4.8 from a ppa, remove them can speed up the build.