### PR TITLE
[Test] "nvm alias" lts test bug fix

### DIFF
--- a/test/fast/Aliases/lts/"nvm alias" should ensure LTS alias dir exists
+++ b/test/fast/Aliases/lts/"nvm alias" should ensure LTS alias dir exists
@@ -7,6 +7,8 @@ set -ex
 
 LTS_ALIAS_PATH="$(nvm_alias_path)/lts"
 
+rm -rf "${LTS_ALIAS_PATH}"
+
 die () { echo "$@" ; exit 1; }
 
 [ ! -d "${LTS_ALIAS_PATH}" ] || die "'${LTS_ALIAS_PATH}' exists and should not"


### PR DESCRIPTION
"$(nvm_alias_path)/lts" may be created during the test, should backup/remove the old one before testing.