### PR TITLE
[Tests] Improve "curl" remove method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 install:
   - if [ -n "${SHELLCHECK-}" ]; then cabal update && cabal install ShellCheck && shellcheck --version ; fi
   - if [ -z "${SHELLCHECK-}" ]; then nvm install node && npm install && npm prune && npm ls urchin doctoc; fi
-  - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
+  - '[ -z "$WITHOUT_CURL" ] || sudo rm -rf "$(which curl)"'
 script:
   - if [ -n "${DOCTOCCHECK-}" ]; then cp README.markdown README.markdown.orig && npm run doctoc && diff -q README.markdown README.markdown.orig ; fi
   - if [ -n "${SHELLCHECK-}" ]; then shellcheck -s bash nvm.sh && shellcheck -s sh nvm.sh && shellcheck -s dash nvm.sh && shellcheck -s ksh nvm.sh ; fi


### PR DESCRIPTION
Prevent apt-get involved, so no package dependency matrix calculation needed, directly delete curl is much more faster and easier.