### PR TITLE
Note that NVM doesn't support Windows was removed

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,10 +34,6 @@
 
 If you're running a system without prepackaged binary available, which means you're going to install nodejs or io.js from its source code, you need to make sure your system has a C++ compiler. For OS X, Xcode will work, for Debian/Ubuntu based GNU/Linux, the `build-essential` and `libssl-dev` packages work.
 
-**Note:** `nvm` does not support Windows (see [#284](https://github.com/creationix/nvm/issues/284)). Two alternatives exist, which are neither supported nor developed by us:
- - [nvm-windows](https://github.com/coreybutler/nvm-windows)
- - [nodist](https://github.com/marcelklehr/nodist)
-
 **Note:** `nvm` does not support [Fish] either (see [#303](https://github.com/creationix/nvm/issues/303)). Alternatives exist, which are neither supported nor developed by us:
  - [bass](https://github.com/edc/bass) allows you to use utilities written for Bash in fish shell
  - [fast-nvm-fish](https://github.com/brigand/fast-nvm-fish) only works with version numbers (not aliases) but doesn't significantly slow your shell startup


### PR DESCRIPTION
Note that NVM doesn't support Windows was removed because the following reasons:
- Referencing issue #284 closed for now,
- Today installed 1.1.3 installed for Windows -- works fine as yet.