### PR TITLE
Install a version before use, if missing

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2639,6 +2639,17 @@ nvm() {
       unset NVM_BIN
     ;;
     "use" )
+      # If version not available, install it first, then use it
+      if [ -n "$1" ] && [ "$1" != "--silent" ] && \
+         ! nvm ls $1 &>/dev/null ; then
+        args=("$@")       # Preserve positional parameters
+
+        nvm install "$@"
+        [ $? -ne 0 ] && return 127  # Return immediately if install fails
+
+        set "${args[@]}"  # Restore positional parameters
+      fi
+
       local PROVIDED_VERSION
       local NVM_USE_SILENT
       NVM_USE_SILENT=0


### PR DESCRIPTION
Now 'nvm use' checks whether the version is installed before it is used.
If the version is missing, it will call 'nvm install' and install it.
Otherwise, if the version is present, it will use it and continue as usual.