### PR TITLE
[Docs] Install script - Improve installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Eg: `curl ... | NVM_DIR=/usr/local/nvm bash` for a global install.
 
 <sub>*NB. The installer can use `git`, `curl`, or `wget` to download `nvm`, whatever is available.*</sub>
 
-**Note:** On OS X, if you get `nvm: command not found` after running the install script, your system may not have a [.bash_profile file] where the command is set up. Simply create one with `touch ~/.bash_profile` and run the install script again.
+**Note:** On OS X, if you get `nvm: command not found` after running the install script, one of the following might be the reason:-  
+ - your system may not have a [`.bash_profile file`] where the command is set up. Simply create one with `touch ~/.bash_profile` and run the install script again
+ - you might need to restart your terminal instance. Try opening a new tab/window in your terminal and retry.
 
 If the above doesn't fix the problem, open your `.bash_profile` and add the following line of code:
 


### PR DESCRIPTION
If installation is prompted to be successful, yet `nvm` command returns `nvm: command not found` then you might need to restart your terminal instance. Try opening a new tab/window in your terminal and retry.