### PR TITLE
[Fix] curl should fail if something wrong, fix #1556

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -110,11 +110,12 @@ nvm_download() {
     if nvm_curl_use_compression; then
       CURL_COMPRESSED_FLAG="--compressed"
     fi
-    curl "${CURL_COMPRESSED_FLAG:-}" -q "$@"
+    curl --fail "${CURL_COMPRESSED_FLAG:-}" -q "$@"
   elif nvm_has "wget"; then
     # Emulate curl with wget
     ARGS=$(nvm_echo "$@" | command sed -e 's/--progress-bar /--progress=bar /' \
                            -e 's/--compressed //' \
+                           -e 's/--fail //' \
                            -e 's/-L //' \
                            -e 's/-I /--server-response /' \
                            -e 's/-s /-q /' \


### PR DESCRIPTION
from curl man page:
```
 -f, --fail
              (HTTP) Fail silently (no output at all) on server errors. This is mostly done to better enable scripts  etc  to  better  deal
              with failed attempts. In normal cases when an HTTP server fails to deliver a document, it returns an HTML document stating so
              (which often also describes why and more). This flag will prevent curl from outputting that and return error 22.
```