### PR TITLE
Allow cache dir to be overridden with NVM_CACHE_DIR

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2231,7 +2231,11 @@ nvm_check_file_permissions() {
 }
 
 nvm_cache_dir() {
-  nvm_echo "${NVM_DIR}/.cache"
+  if [ -n "$NVM_CACHE_DIR" ]; then
+    nvm_echo "$NVM_CACHE_DIR"
+  else
+    nvm_echo "$NVM_DIR/.cache"
+  fi
 }
 
 nvm() {


### PR DESCRIPTION
Hello,

I added the possibility to override the cache directory that nvm uses.
I ran into a problem with a combination of electron-compile and electron-mocha, where electron-compile thought the nvm cache is its compile cache, and hilarity ensued. Anyway, I use it like this:
```sh
export NVM_DIR="$HOME/.nvm"
export NVM_CACHE_DIR=$NVM_DIR/.nvm_cache
[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
```

Thanks,
Wolfgang
