### PR TITLE
[New] Add `--auto` to git gc to speed up install & upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -125,7 +125,7 @@ install_nvm_from_git() {
   fi
 
   echo "=> Compressing and cleaning up git repository"
-  if ! command git --git-dir="$INSTALL_DIR"/.git --work-tree="$INSTALL_DIR" gc --aggressive --prune=now ; then
+  if ! command git --git-dir="$INSTALL_DIR"/.git --work-tree="$INSTALL_DIR" gc --auto --aggressive --prune=now ; then
     echo >&2 "Your version of git is out of date. Please update it!"
   fi
   return


### PR DESCRIPTION
Use `--auto` can really help speed up the upgrade and also install process if there is no need to re-compress all the objects, just let `git` to decide it.

Not sure if GitHub has optimized their git backend server, I noticed that now a new clone of `nvm` would only a single pack in the .git objects which means it's already compressed, we don't need to force it.