### PR TITLE
[New] Clean up git reflog history before git gc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -125,6 +125,9 @@ install_nvm_from_git() {
   fi
 
   echo "=> Compressing and cleaning up git repository"
+  if ! command git --git-dir="$INSTALL_DIR"/.git --work-tree="$INSTALL_DIR" reflog expire --expire=now --all; then
+    echo >&2 "Your version of git is out of date. Please update it!"
+  fi
   if ! command git --git-dir="$INSTALL_DIR"/.git --work-tree="$INSTALL_DIR" gc --auto --aggressive --prune=now ; then
     echo >&2 "Your version of git is out of date. Please update it!"
   fi


### PR DESCRIPTION
This can help improve the result of garbage collection. By tracing the [doc](https://git-scm.com/docs/git-reflog/1.5.0) of `reflog`, I think it's a feature just come with `reflog` from the beginning, which is git v1.5 series since 2006.