### PR TITLE
Also unset NVM_RC_VERSION when unloading

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -3408,7 +3408,7 @@ nvm() {
         node_version_has_solaris_binary iojs_version_has_solaris_binary \
         nvm_curl_libz_support nvm_command_info \
         > /dev/null 2>&1
-      unset RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR NVM_DIR \
+      unset NVM_RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR NVM_DIR \
         NVM_CD_FLAGS NVM_BIN NVM_MAKE_JOBS \
         > /dev/null 2>&1
     ;;


### PR DESCRIPTION
`nvm_unload` was unsetting `RC_VERSION` instead of `NVM_RC_VERSION`. Am I correct in thinking this was a typo?