### PR TITLE
Remove the manual ShellCheck install proecss on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 addons:
   apt:
     packages:
-      - cabal-install
       - ghc
       - zsh
     #  - ksh
@@ -15,7 +14,6 @@ cache:
   directories:
     - $HOME/.npm
     - $HOME/.ghc
-    - $HOME/.cabal
     - $TRAVIS_BUILD_DIR/.cache
     - $TRAVIS_BUILD_DIR/node_modules
 before_install:
@@ -23,7 +21,6 @@ before_install:
   - curl --version
   - wget --version
 install:
-  - if [ -n "${SHELLCHECK-}" ]; then cabal update && cabal install ShellCheck && shellcheck --version ; fi
   - if [ -z "${SHELLCHECK-}" ]; then nvm install node && npm install && npm prune && npm ls urchin doctoc; fi
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
 script:
@@ -38,7 +35,7 @@ env:
   global:
     - CXX=g++-4.8
     - CC=gcc-4.8
-    - PATH="~/.cabal/bin/:$(echo $PATH | sed 's/::/:/')"
+    - PATH="$(echo $PATH | sed 's/::/:/')"
     - NVM_DIR="${TRAVIS_BUILD_DIR}"
   matrix:
     - MAKE_RELEASE=true


### PR DESCRIPTION
Travis CI now provides the latest ShellCheck and I believe that we don't need to maintain our own installation any more so that we can save both time and resources!