### PR TITLE
Move Travis CI to use container based environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: generic
 dist: trusty
-sudo: required
+sudo: false
 addons:
   apt:
     packages:


### PR DESCRIPTION
Looks like we can move to container based CI environment to speed up the testing.
`sudo` seems to be working in container based environment.