### PR TITLE
Make `nvm cache clear` message less ambiguous

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2363,9 +2363,9 @@ nvm() {
           local DIR
           DIR="$(nvm_cache_dir)"
           if command rm -rf "${DIR}" && command mkdir -p "${DIR}"; then
-            nvm_echo 'Cache cleared.'
+            nvm_echo 'nvm cache cleared.'
           else
-            nvm_err "Unable to clear cache: ${DIR}"
+            nvm_err "Unable to clear nvm cache: ${DIR}"
             return 1
           fi
         ;;
@@ -3346,7 +3346,7 @@ nvm() {
     ;;
     "clear-cache" )
       command rm -f "$NVM_DIR/v*" "$(nvm_version_dir)" 2>/dev/null
-      nvm_echo 'Cache cleared.'
+      nvm_echo 'nvm cache cleared.'
     ;;
     "version" )
       nvm_version "${1}"


### PR DESCRIPTION
I have a [Bash function](https://github.com/citrusui/functions/blob/120b525d11da1a5d8fbdff80f0f68bd06fd5d171/.functions#L6) that I use to clear out my `apt` and `nvm` caches.

![screenshot from 2017-10-28 20 31 28](https://user-images.githubusercontent.com/9056756/32139698-0367e3b0-bc1f-11e7-8195-8ef10f8a99f2.png)

---

If you weren't aware `nvm` was on your system, the last line (above) is likely to cause some confusion. **Here's a simple fix:**

![screenshot from 2017-10-28 20 37 46](https://user-images.githubusercontent.com/9056756/32139720-ecfd3c32-bc1f-11e7-9206-94343f86cee7.png)
