### PR TITLE
Fix for $path used by zsh

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -13,13 +13,7 @@
 NVM_SCRIPT_SOURCE="$_"
 
 nvm_echo() {
-  command printf %s\\n "$*" 2>/dev/null || {
-    nvm_echo() {
-      # shellcheck disable=SC1001
-      \printf %s\\n "$*" # on zsh, `command printf` sometimes fails
-    }
-    nvm_echo "$@"
-  }
+  command printf %s\\n "$*" 2>/dev/null
 }
 
 nvm_cd() {

--- a/nvm.sh
+++ b/nvm.sh
@@ -273,12 +273,12 @@ nvm_tree_contains_path() {
 
 # Traverse up in directory tree to find containing folder
 nvm_find_up() {
-  local path
-  path="${PWD}"
-  while [ "${path}" != "" ] && [ ! -f "${path}/${1-}" ]; do
-    path=${path%/*}
+  local path_
+  path_="${PWD}"
+  while [ "${path_}" != "" ] && [ ! -f "${path_}/${1-}" ]; do
+    path_=${path_%/*}
   done
-  nvm_echo "${path}"
+  nvm_echo "${path_}"
 }
 
 

--- a/test/fast/Unit tests/nvm_ls_current
+++ b/test/fast/Unit tests/nvm_ls_current
@@ -21,6 +21,7 @@ rm -rf "$TEST_DIR"
 mkdir "$TEST_DIR"
 ln -s "$(command which which)" "$TEST_DIR/which"
 ln -s "$(command which dirname)" "$TEST_DIR/dirname"
+ln -s "$(command which printf)" "$TEST_DIR/printf"
 
 [ "$(PATH="$TEST_DIR" nvm_ls_current)" = "none" ] || die 'when node not installed, nvm_ls_current did not return "none"'
 [ "@$(PATH="$TEST_DIR" nvm_ls_current 2> /dev/stdout 1> /dev/null)@" = "@@" ] || die 'when node not installed, nvm_ls_current returned error output'


### PR DESCRIPTION
The `$path` is used by zsh itself.

Rename `path` to `path_`.

Ref:
"The lower-case version of PATH is an array parameter
bound to the scalar upper-case parameter."
-- http://www.zsh.org/mla/users/2015/msg00178.html