### PR TITLE
Fix a bug that block that installation of node in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -140,22 +140,22 @@ install_nvm_from_git() {
 # Automatically install Node.js
 #
 nvm_install_node() {
-  local NODE_VERSION
-  NODE_VERSION="$(nvm_node_version)"
+  local NODE_VERSION_LOCAL
+  NODE_VERSION_LOCAL="$(nvm_node_version)"
 
-  if [ -z "$NODE_VERSION" ]; then
+  if [ -z "$NODE_VERSION_LOCAL" ]; then
     return 0
   fi
 
-  echo "=> Installing Node.js version $NODE_VERSION"
-  nvm install "$NODE_VERSION"
+  echo "=> Installing Node.js version $NODE_VERSION_LOCAL"
+  nvm install "$NODE_VERSION_LOCAL"
   local CURRENT_NVM_NODE
 
   CURRENT_NVM_NODE="$(nvm_version current)"
-  if [ "$(nvm_version "$NODE_VERSION")" == "$CURRENT_NVM_NODE" ]; then
-    echo "=> Node.js version $NODE_VERSION has been successfully installed"
+  if [ "$(nvm_version "$NODE_VERSION_LOCAL")" == "$CURRENT_NVM_NODE" ]; then
+    echo "=> Node.js version $NODE_VERSION_LOCAL has been successfully installed"
   else
-    echo >&2 "Failed to install Node.js $NODE_VERSION"
+    echo >&2 "Failed to install Node.js $NODE_VERSION_LOCAL"
   fi
 }
 

--- a/test/install_script/nvm_install_with_node_version
+++ b/test/install_script/nvm_install_with_node_version
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+NODE_VERSION=8 \. ../../install.sh
+
+# nvm installed node 8
+(nvm ls | grep 8) > /dev/null 2>&1 || die "nvm didn't install node 8"

--- a/test/install_script/nvm_install_with_node_version
+++ b/test/install_script/nvm_install_with_node_version
@@ -5,4 +5,4 @@ die () { echo "$@" ; exit 1; }
 NODE_VERSION=8 \. ../../install.sh
 
 # nvm installed node 8
-(nvm ls | grep 8) > /dev/null 2>&1 || die "nvm didn't install node 8"
+nvm ls 8 > /dev/null 2>&1 || die "nvm didn't install node 8"


### PR DESCRIPTION
Hi,

I found a bug in `nvm_install_node` function, it overrides the variable NODE_VERSION, which blocks the installation of node in the install.sh script! More details below..

I did some tests locally with the install.sh script, and the I found that the problem in in the function `nvm_install_node` in [install.sh](https://github.com/creationix/nvm/blob/master/install.sh#L143) script.

One solution is to change the name of the local variable to something other than NODE_VERSION

You could test it using these 2 scripts:

I ran tests on ubuntu 16.04 servers

- Current version [0.33.6] test script:
  `export NODE_VERSION=8 && sudo curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash`

Expected result: nvm should install node 8
Result: node 8 doesn't get installed
```bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12492  100 12492    0     0  68946      0 --:--:-- --:--:-- --:--:-- 69016
=> nvm is already installed in /home/ubuntu/.nvm, trying to update using git
=> => Compressing and cleaning up git repository

=> nvm source string already in /home/ubuntu/.bashrc
=> bash_completion source string already in /home/ubuntu/.bashrc
=> Close and reopen your terminal to start using nvm or run the following to use it now:

export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
```

- Proposed fix test script:
  `export NODE_VERSION=8 && sudo curl -o- https://raw.githubusercontent.com/Quadric/nvm/fix-node-version-in-install-script/install.sh | bash`

Result: node 8 is installed
```bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12540  100 12540    0     0  48598      0 --:--:-- --:--:-- --:--:-- 48604
=> nvm is already installed in /home/ubuntu/.nvm, trying to update using git
=> => Compressing and cleaning up git repository

=> nvm source string already in /home/ubuntu/.bashrc
=> bash_completion source string already in /home/ubuntu/.bashrc
=> Installing Node.js version 8
v8.9.1 is already installed.
Now using node v8.9.1 (npm v5.5.1)
=> Node.js version 8 has been successfully installed
=> Close and reopen your terminal to start using nvm or run the following to use it now:

export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
```

I wrote a test for it, and ran "test/install_script" on original repo and my fix, and surprisingly the test passes on both!! (https://github.com/Quadric/nvm/blob/fix-node-version-in-install-script/test/install_script/nvm_install_with_node_version), it doesn't change the fact that it still fails when I provision an AWS AMI with packer or when I run the script directly on the newly created machine!

thanks for you efforts :) :+1: