### PR TITLE
`nvm use`: perfect pre-npm-config env var checking

### DIFF
--- a/test/fast/Unit tests/nvm_die_on_prefix
+++ b/test/fast/Unit tests/nvm_die_on_prefix
@@ -46,16 +46,23 @@ OUTPUT="$(nvm_die_on_prefix 0 foo 2>&1)"
 OUTPUT="$(PREFIX=bar nvm_die_on_prefix 0 foo 2>&1)"
 EXPECTED_OUTPUT='nvm is not compatible with the "PREFIX" environment variable: currently set to "bar"
 Run `unset PREFIX` to unset it.'
-EXIT_CODE="$(PREFIX=bar nvm_die_on_prefix 0 foo >/dev/null 2>&1; echo $?)"
+EXIT_CODE="$(export PREFIX=bar ; nvm_die_on_prefix 0 foo >/dev/null 2>&1; echo $?)"
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'PREFIX=bar nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
 [ "_$EXIT_CODE" = "_3" ] || die "'PREFIX=bar nvm_die_on_prefix 0 foo' did not exit with 3; got '$EXIT_CODE'"
 
-OUTPUT="$(NPM_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo 2>&1)"
+OUTPUT="$(export NPM_CONFIG_PREFIX=bar ; nvm_die_on_prefix 0 foo 2>&1)"
 EXPECTED_OUTPUT='nvm is not compatible with the "NPM_CONFIG_PREFIX" environment variable: currently set to "bar"
 Run `unset NPM_CONFIG_PREFIX` to unset it.'
-EXIT_CODE="$(NPM_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo >/dev/null 2>&1; echo $?)"
+EXIT_CODE="$(export NPM_CONFIG_PREFIX=bar ; nvm_die_on_prefix 0 foo >/dev/null 2>&1; echo $?)"
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'NPM_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
 [ "_$EXIT_CODE" = "_4" ] || die "'NPM_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not exit with 4; got '$EXIT_CODE'"
+
+OUTPUT="$(export npm_CONFIG_PREFIX=bar ; nvm_die_on_prefix 0 foo 2>&1)"
+EXPECTED_OUTPUT='nvm is not compatible with the "npm_CONFIG_PREFIX" environment variable: currently set to "bar"
+Run `unset npm_CONFIG_PREFIX` to unset it.'
+EXIT_CODE="$(export npm_CONFIG_PREFIX=bar ; nvm_die_on_prefix 0 foo >/dev/null 2>&1; echo $?)"
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'npm_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+[ "_$EXIT_CODE" = "_4" ] || die "'npm_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not exit with 4; got '$EXIT_CODE'"
 
 npm() {
   local args


### PR DESCRIPTION
@zkat @iarna: I would dearly love your input on this change; if this env var checking is good, then I can next replace `npm config get prefix` with "searching .npmrc files", which will give nvm a huge performance boost.