### PR TITLE
ShellCheck v0.4.7 fixes

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -10,6 +10,7 @@ __nvm_generate_completion()
 {
   declare current_word
   current_word="${COMP_WORDS[COMP_CWORD]}"
+  # shellcheck disable=SC2207
   COMPREPLY=($(compgen -W "$1" -- "$current_word"))
   return 0
 }

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ install_nvm_from_git() {
 
   if [ -d "$INSTALL_DIR/.git" ]; then
     echo "=> nvm is already installed in $INSTALL_DIR, trying to update using git"
-    command printf "\r=> "
+    command printf '\r=> '
     command git --git-dir="$INSTALL_DIR"/.git --work-tree="$INSTALL_DIR" fetch origin tag "$(nvm_latest_version)" --depth=1 2> /dev/null || {
       echo >&2 "Failed to update nvm, run 'git fetch' in $INSTALL_DIR yourself."
       exit 1
@@ -93,7 +93,7 @@ install_nvm_from_git() {
   else
     # Cloning to $INSTALL_DIR
     echo "=> Downloading nvm from git to '$INSTALL_DIR'"
-    command printf "\r=> "
+    command printf '\r=> '
     mkdir -p "${INSTALL_DIR}"
     if [ "$(ls -A "${INSTALL_DIR}")" ]; then
       command git init "${INSTALL_DIR}" || {
@@ -325,8 +325,9 @@ nvm_do_install() {
   local PROFILE_INSTALL_DIR
   PROFILE_INSTALL_DIR="$(nvm_install_dir| sed "s:^$HOME:\$HOME:")"
 
-  SOURCE_STR="\nexport NVM_DIR=\"${PROFILE_INSTALL_DIR}\"\n[ -s \"\$NVM_DIR/nvm.sh\" ] && \\. \"\$NVM_DIR/nvm.sh\"  # This loads nvm\n"
-  COMPLETION_STR="[ -s \"\$NVM_DIR/bash_completion\" ] && \\. \"\$NVM_DIR/bash_completion\"  # This loads nvm bash_completion\n"
+  SOURCE_STR="\\nexport NVM_DIR=\"${PROFILE_INSTALL_DIR}\"\\n[ -s \"\$NVM_DIR/nvm.sh\" ] && \\. \"\$NVM_DIR/nvm.sh\"  # This loads nvm\\n"
+  # shellcheck disable=SC2016
+  COMPLETION_STR='[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion\n'
   BASH_OR_ZSH=false
 
   if [ -z "${NVM_PROFILE-}" ] ; then

--- a/nvm.sh
+++ b/nvm.sh
@@ -53,7 +53,7 @@ nvm_command_info() {
     INFO="$(which "${COMMAND}") ($(type "${COMMAND}" | command awk '{ $1=$2=$3=$4="" ;print }' | command sed -e 's/^\ *//g' -Ee "s/\`|'//g" ))"
   elif type "${COMMAND}" | nvm_grep -q "^${COMMAND} is an alias for"; then
     INFO="$(which "${COMMAND}") ($(type "${COMMAND}" | command awk '{ $1=$2=$3=$4=$5="" ;print }' | command sed 's/^\ *//g'))"
-  elif type "${COMMAND}" | nvm_grep -q "^${COMMAND} is \/"; then
+  elif type "${COMMAND}" | nvm_grep -q "^${COMMAND} is \\/"; then
     INFO="$(type "${COMMAND}" | command awk '{print $3}')"
   else
     INFO="$(type "${COMMAND}")"
@@ -84,7 +84,7 @@ nvm_get_latest() {
     if nvm_curl_use_compression; then
       CURL_COMPRESSED_FLAG="--compressed"
     fi
-    NVM_LATEST_URL="$(curl ${CURL_COMPRESSED_FLAG:-} -q -w "%{url_effective}\n" -L -s -S http://latest.nvm.sh -o /dev/null)"
+    NVM_LATEST_URL="$(curl ${CURL_COMPRESSED_FLAG:-} -q -w "%{url_effective}\\n" -L -s -S http://latest.nvm.sh -o /dev/null)"
   elif nvm_has "wget"; then
     NVM_LATEST_URL="$(wget http://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
   else
@@ -645,16 +645,16 @@ nvm_print_formatted_alias() {
   DEST_FORMAT='%s'
   VERSION_FORMAT='%s'
   local NEWLINE
-  NEWLINE="\n"
+  NEWLINE='\n'
   if [ "_${DEFAULT}" = '_true' ]; then
-    NEWLINE=" (default)\n"
+    NEWLINE=' (default)\n'
   fi
   local ARROW
   ARROW='->'
   if [ -z "${NVM_NO_COLORS}" ] && nvm_has_colors; then
     ARROW='\033[0;90m->\033[0m'
     if [ "_${DEFAULT}" = '_true' ]; then
-      NEWLINE=" \033[0;37m(default)\033[0m\n"
+      NEWLINE=' \033[0;37m(default)\033[0m\n'
     fi
     if [ "_${VERSION}" = "_${NVM_CURRENT-}" ]; then
       ALIAS_FORMAT='\033[0;32m%s\033[0m'
@@ -832,7 +832,7 @@ nvm_resolve_alias() {
       break
     fi
 
-    SEEN_ALIASES="${SEEN_ALIASES}\n${ALIAS_TEMP}"
+    SEEN_ALIASES="${SEEN_ALIASES}\\n${ALIAS_TEMP}"
     ALIAS="${ALIAS_TEMP}"
   done
 
@@ -1021,25 +1021,23 @@ nvm_ls() {
       PATTERN='v'
       SEARCH_PATTERN='.*'
     else
-      SEARCH_PATTERN="$(echo "${PATTERN}" | command sed "s#\.#\\\.#g;")"
+      SEARCH_PATTERN="$(echo "${PATTERN}" | command sed 's#\.#\\\.#g;')"
     fi
     if [ -n "${NVM_DIRS_TO_SEARCH1}${NVM_DIRS_TO_SEARCH2}${NVM_DIRS_TO_SEARCH3}" ]; then
       VERSIONS="$(command find "${NVM_DIRS_TO_SEARCH1}"/* "${NVM_DIRS_TO_SEARCH2}"/* "${NVM_DIRS_TO_SEARCH3}"/* -name . -o -type d -prune -o -path "${PATTERN}*" \
         | command sed -e "
             s#${NVM_VERSION_DIR_IOJS}/#versions/${NVM_IOJS_PREFIX}/#;
             s#^${NVM_DIR}/##;
-            \#^[^v]# d;
-            \#^versions\$# d;
+            \\#^[^v]# d;
+            \\#^versions\$# d;
             s#^versions/##;
             s#^v#${NVM_NODE_PREFIX}/v#;
-            \#${SEARCH_PATTERN}# !d;
+            \\#${SEARCH_PATTERN}# !d;
           " \
-          -e "s#^\([^/]\{1,\}\)/\(.*\)\$#\2.\1#;" \
+          -e 's#^\([^/]\{1,\}\)/\(.*\)$#\2.\1#;' \
         | command sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n \
-        | command sed "
-            s#\(.*\)\.\([^\.]\{1,\}\)\$#\2-\1#;
-            s#^${NVM_NODE_PREFIX}-##;
-          " \
+        | command sed -e 's#\(.*\)\.\([^\.]\{1,\}\)$#\2-\1#;' \
+                      -e "s#^${NVM_NODE_PREFIX}-##;" \
       )"
     fi
 
@@ -1405,7 +1403,7 @@ nvm_print_versions() {
           LTS="${LTS##Latest }"
           LTS_LENGTH="${#LTS}"
           if [ "${NVM_HAS_COLORS-}" = '1' ]; then
-            LTS_FORMAT="  \033[1;32m%${LTS_LENGTH}s\033[0m"
+            LTS_FORMAT="  \\033[1;32m%${LTS_LENGTH}s\\033[0m"
           else
             LTS_FORMAT="  %${LTS_LENGTH}s"
           fi
@@ -1413,15 +1411,15 @@ nvm_print_versions() {
         *)
           LTS_LENGTH="${#LTS}"
           if [ "${NVM_HAS_COLORS-}" = '1' ]; then
-            LTS_FORMAT="  \033[0;37m%${LTS_LENGTH}s\033[0m"
+            LTS_FORMAT="  \\033[0;37m%${LTS_LENGTH}s\\033[0m"
           else
             LTS_FORMAT="  %${LTS_LENGTH}s"
           fi
         ;;
       esac
-      command printf -- "${FORMAT}${LTS_FORMAT}\n" "$VERSION" " $LTS"
+      command printf -- "${FORMAT}${LTS_FORMAT}\\n" "$VERSION" " $LTS"
     else
-      command printf -- "${FORMAT}\n" "$VERSION"
+      command printf -- "${FORMAT}\\n" "$VERSION"
     fi
   done
 }


### PR DESCRIPTION
ShellCheck v0.4.7 just released 6 hours ago and hopefully will be deployed on Travis CI soon.
This is the fix for [SC2207](https://github.com/koalaman/shellcheck/wiki/SC2207) and [SC1117](https://github.com/koalaman/shellcheck/wiki/SC1117)