### PR TITLE
[Fix] Add missing "command" prefixes for few commands

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ nvm_has() {
 }
 
 nvm_install_dir() {
-  printf %s "${NVM_DIR:-"$HOME/.nvm"}"
+  command printf %s "${NVM_DIR:-"$HOME/.nvm"}"
 }
 
 nvm_latest_version() {
@@ -188,7 +188,7 @@ install_nvm_as_script() {
     echo >&2 "Failed to download '$NVM_BASH_COMPLETION_SOURCE'"
     return 2
   } &
-  for job in $(jobs -p | sort)
+  for job in $(jobs -p | command sort)
   do
     wait "$job" || return $?
   done
@@ -268,7 +268,7 @@ nvm_check_global_modules() {
   MODULE_COUNT="$(
     command printf %s\\n "$NPM_GLOBAL_MODULES" |
     command sed -ne '1!p' |                     # Remove the first line
-    wc -l | tr -d ' '                           # Count entries
+    wc -l | command tr -d ' '                   # Count entries
   )"
 
   if [ "${MODULE_COUNT}" != '0' ]; then
@@ -327,7 +327,7 @@ nvm_do_install() {
   local NVM_PROFILE
   NVM_PROFILE="$(nvm_detect_profile)"
   local PROFILE_INSTALL_DIR
-  PROFILE_INSTALL_DIR="$(nvm_install_dir | sed "s:^$HOME:\$HOME:")"
+  PROFILE_INSTALL_DIR="$(nvm_install_dir | command sed "s:^$HOME:\$HOME:")"
 
   SOURCE_STR="\\nexport NVM_DIR=\"${PROFILE_INSTALL_DIR}\"\\n[ -s \"\$NVM_DIR/nvm.sh\" ] && \\. \"\$NVM_DIR/nvm.sh\"  # This loads nvm\\n"
   # shellcheck disable=SC2016

--- a/nvm.sh
+++ b/nvm.sh
@@ -293,7 +293,7 @@ nvm_rc_version() {
     nvm_err "No .nvmrc file found"
     return 1
   fi
-  read -r NVM_RC_VERSION < "${NVMRC_PATH}" || printf ''
+  read -r NVM_RC_VERSION < "${NVMRC_PATH}" || command printf ''
   if [ ! -n "${NVM_RC_VERSION}" ]; then
     nvm_err "Warning: empty .nvmrc file found at \"${NVMRC_PATH}\""
     return 2
@@ -2402,7 +2402,7 @@ nvm() {
       nvm_err "\$NVM_NODEJS_ORG_MIRROR: '${NVM_NODEJS_ORG_MIRROR}'"
       nvm_err "\$NVM_IOJS_ORG_MIRROR: '${NVM_IOJS_ORG_MIRROR}'"
       nvm_err "shell version: '$(${SHELL} --version | command head -n 1)'"
-      nvm_err "uname -a: '$(uname -a | awk '{$2=""; print}' | xargs)'"
+      nvm_err "uname -a: '$(command uname -a | command awk '{$2=""; print}' | command xargs)'"
       if [ "$(nvm_get_os)" = "darwin" ] && nvm_has sw_vers; then
         nvm_err "OS version: $(sw_vers | command awk '{print $2}' | command xargs)"
       elif [ -r "/etc/issue" ]; then
@@ -2583,7 +2583,7 @@ nvm() {
           [ -n "${line}" ] || continue
 
           # Skip comment lines that begin with `#`.
-          [ "$(echo "$line" | cut -c1)" != "#" ] || continue
+          [ "$(echo "$line" | command cut -c1)" != "#" ] || continue
 
           # Fail on lines that have multiple space-separated words
           case ${line} in


### PR DESCRIPTION
Just take a deeper look to find out those commands suppose to have `command` prefix but was missing, so fix now.