### PR TITLE
Add a way to load a specific version of node during shell startup

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -3510,7 +3510,10 @@ nvm_auto() {
       nvm install >/dev/null
     fi
   elif [ "_$NVM_MODE" = '_use' ]; then
-    VERSION="$(nvm_resolve_local_alias default 2>/dev/null || nvm_echo)"
+    VERSION="$NVM_AUTO_LOAD_VERSION"
+    if [ -z "$VERSION" ]; then
+      VERSION="$(nvm_resolve_local_alias default 2>/dev/null || nvm_echo)"
+    fi
     if [ -n "$VERSION" ]; then
       nvm use --silent "$VERSION" >/dev/null
     elif nvm_rc_version >/dev/null 2>&1; then


### PR DESCRIPTION
This allows avoiding `nvm_resolve_local_alias default` during shell initialization, which can be fairly slow on underpowered machines.

See discussion starting at https://github.com/creationix/nvm/issues/1261#issuecomment-366879288 for details.