### PR TITLE
[New] Add EditorConfig to help maintain part of coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+tab_width = 2
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.txt]
+indent_size = false
+
+[Makefile]
+indent_style = tab

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,12 @@ before_install:
   - curl --version
   - wget --version
 install:
-  - if [ -z "${SHELLCHECK-}" ]; then nvm install node && npm install && npm prune && npm ls urchin doctoc; fi
+  - if [ -z "${SHELLCHECK-}" ]; then nvm install node && npm install && npm prune && npm ls urchin doctoc eclint; fi
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
 script:
   - if [ -n "${MAKE_RELEASE-}" ]; then export GIT_EDITOR="sed -i '1 s/^/99.99.99 make release test/'" && git fetch --unshallow --tags && echo proceed | make TAG=99.99.99 release ; fi
   - if [ -n "${DOCTOCCHECK-}" ]; then cp README.md README.md.orig && npm run doctoc && diff -q README.md README.md.orig ; fi
+  - if [ -n "${ECLINT-}" ]; then npm run eclint ; fi
   - if [ -n "${SHELLCHECK-}" ]; then shellcheck -s bash nvm.sh && shellcheck -s sh nvm.sh && shellcheck -s dash nvm.sh && shellcheck -s ksh nvm.sh ; fi
   - if [ -n "${SHELLCHECK-}" ]; then shellcheck -s bash install.sh bash_completion nvm-exec ; fi
   - if [ -n "${SHELL-}" ] && [ -n "${TEST_SUITE}" ]; then if [ "${TEST_SUITE}" = 'installation_iojs' ]; then travis_retry make TEST_SUITE=$TEST_SUITE URCHIN="$(npm bin)/urchin" test-$SHELL ; else make TEST_SUITE=$TEST_SUITE URCHIN="$(npm bin)/urchin" test-$SHELL; fi; fi
@@ -39,6 +40,7 @@ env:
     - MAKE_RELEASE=true
     - DOCTOCCHECK=true
     - SHELLCHECK=true
+    - ECLINT=true
     - SHELL=bash TEST_SUITE=install_script
     - SHELL=sh TEST_SUITE=fast
     - SHELL=dash TEST_SUITE=fast

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test/installation/node": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=installation_node test-$shell",
     "test/installation/iojs": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=installation_iojs test-$shell",
     "test/sourcing": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=sourcing test-$shell",
-    "doctoc": "doctoc --title='## Table of Contents' --github README.md"
+    "doctoc": "doctoc --title='## Table of Contents' --github README.md",
+    "eclint": "eclint check ."
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,7 @@
   },
   "homepage": "https://github.com/creationix/nvm",
   "devDependencies": {
+    "eclint": "^2.6.0",
     "replace": "^0.3.0",
     "semver": "^5.0.1",
     "urchin": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test/installation/iojs": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=installation_iojs test-$shell",
     "test/sourcing": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=sourcing test-$shell",
     "doctoc": "doctoc --title='## Table of Contents' --github README.md",
-    "eclint": "eclint check ."
+    "eclint": "eclint check $(git ls-tree --name-only HEAD | xargs)"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
[EditorConfig](http://editorconfig.org/) is a famous open source project which can help us maintain part of the coding style easily, including:
- indentation (tab or space, indent size, tab width)
- trailing space
- end of line char
- final newline char at end of file

and some other features ...

It's supported by **GitHub**(and some other IDEs, editors) **natively**, so commits made on GitHub web GUI will simply follow the config, and most of the famous IDEs/editors like vim, atom, vscode, sublime, emacs, notepad++, gedit, etc, also support it easily by using plugin/extension, it's also introduced in many projects to help maintain the code readability, coding style, I believe it worth us to use it in nvm, we can save some commits for coding style fixing by using EditorConfig, and can integrate it with some tests in future.