### PR TITLE
[Fix] Improve .nvmrc reading process

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -293,7 +293,7 @@ nvm_rc_version() {
     nvm_err "No .nvmrc file found"
     return 1
   fi
-  read -r NVM_RC_VERSION < "${NVMRC_PATH}" || command printf ''
+  NVM_RC_VERSION="$(command head -n 1 "${NVMRC_PATH}" | command tr -d '\r')" || command printf ''
   if [ ! -n "${NVM_RC_VERSION}" ]; then
     nvm_err "Warning: empty .nvmrc file found at \"${NVMRC_PATH}\""
     return 2

--- a/test/fast/Running "nvm use" should drop CR char automatically.
+++ b/test/fast/Running "nvm use" should drop CR char automatically.
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -ex
+
+die () { echo "$@" ; cleanup ; exit 1; }
+
+cleanup() {
+  unset VERSION1 VERSION2 VERSION3
+  rm .nvmrc
+}
+
+\. ../../nvm.sh
+
+# normal .nvmrc
+printf '0.999.0\n'   > .nvmrc
+nvm_rc_version
+VERSION1="${NVM_RC_VERSION}"
+
+# .nvmrc with CR char
+printf '0.999.0\r\n' > .nvmrc
+nvm_rc_version
+VERSION2="${NVM_RC_VERSION}"
+
+[ "${VERSION1}" = "${VERSION2}" ]
+
+# .nvmrc without any newline char
+printf '0.999.0' > .nvmrc
+nvm_rc_version
+VERSION3="${NVM_RC_VERSION}"
+
+[ "${VERSION1}" = "${VERSION3}" ]
+
+cleanup


### PR DESCRIPTION
Improve how we read the version in `.nvmrc` to avoid the impact of `CR`/`CRLF` as newline char.

Fixes #1015. Fixes #1712.