### PR TITLE
Reduce bash_completion startup time

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2,7 +2,7 @@
 
 # bash completion for Node Version Manager (NVM)
 
-if ! nvm &> /dev/null; then
+if ! command -v nvm &> /dev/null; then
     return
 fi
 


### PR DESCRIPTION
```bash
command -v nvm
```
is a lot faster than
```bash
nvm
```
period.

This significantly cuts shell login time.