### PR TITLE
Turn off wget's output in nvm_get_latest()

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -86,7 +86,7 @@ nvm_get_latest() {
     fi
     NVM_LATEST_URL="$(curl ${CURL_COMPRESSED_FLAG:-} -q -w "%{url_effective}\\n" -L -s -S http://latest.nvm.sh -o /dev/null)"
   elif nvm_has "wget"; then
-    NVM_LATEST_URL="$(wget http://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
+    NVM_LATEST_URL="$(wget -q http://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
   else
     nvm_err 'nvm needs curl or wget to proceed.'
     return 1

--- a/test/slow/nvm_get_latest/nvm_get_latest
+++ b/test/slow/nvm_get_latest/nvm_get_latest
@@ -11,7 +11,7 @@ cleanup() {
 EXPECTED_VERSION="v12.3.456"
 URL="https://github.com/creationix/nvm/releases/tag/$EXPECTED_VERSION"
 EXPECTED_CURL_ARGS="--compressed -q -w %{url_effective}\n -L -s -S http://latest.nvm.sh -o /dev/null"
-EXPECTED_WGET_ARGS="http://latest.nvm.sh --server-response -O /dev/null"
+EXPECTED_WGET_ARGS="-q http://latest.nvm.sh --server-response -O /dev/null"
 
 curl() {
   if [ $# -eq 1 ] && [ "$1" = "-V" ]; then
@@ -33,20 +33,11 @@ wget() {
   else
     local WGET_CONTENTS
     WGET_CONTENTS="
---2014-12-21 18:11:14--  http://latest.nvm.sh/
-Resolving latest.nvm.sh... 50.31.209.229
-Connecting to latest.nvm.sh|50.31.209.229|:80... connected.
-HTTP request sent, awaiting response...
   HTTP/1.1 301 Moved Permanently
   Location: https://github.com/creationix/nvm/releases/latest
   Content-Type: text/html; charset=utf-8
   Content-Length: 84
   Date: Mon, 22 Dec 2014 02:11:15 GMT
-Location: https://github.com/creationix/nvm/releases/latest [following]
---2014-12-21 18:11:15--  https://github.com/creationix/nvm/releases/latest
-Resolving github.com... 192.30.252.130
-Connecting to github.com|192.30.252.130|:443... connected.
-HTTP request sent, awaiting response...
   HTTP/1.1 302 Found
   Server: GitHub.com
   Date: Mon, 22 Dec 2014 02:11:15 GMT
@@ -70,10 +61,6 @@ HTTP request sent, awaiting response...
   X-Content-Type-Options: nosniff
   Vary: Accept-Encoding
   X-Served-By: ef97014f01ea59c1ef337fe51a4d0331
-Location: $URL [following]
---2014-12-21 18:11:15--  $URL
-Reusing existing connection to github.com:443.
-HTTP request sent, awaiting response...
   HTTP/1.1 200 OK
   Server: GitHub.com
   Date: Mon, 22 Dec 2014 02:11:15 GMT
@@ -95,13 +82,6 @@ HTTP request sent, awaiting response...
   X-Content-Type-Options: nosniff
   Vary: Accept-Encoding
   X-Served-By: 926b734ea1992f8ee1f88ab967a93dac
-Length: unspecified [text/html]
-Saving to: ‘/dev/null’
-
-     0K .......... .........                                    225K=0.09s
-
-2014-12-21 18:11:15 (225 KB/s) - ‘/dev/null’ saved [20298]
-
 "
     "$WGET_CONTENTS" | while read line
     do


### PR DESCRIPTION
curl output is turned off by `-s` in the same place, we should unify the behavior on wget, also, this help removes those wget outputs that can't fit our coding style tests. cc #1739