### PR TITLE
add --tags to git fetch in manual upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For manual upgrade with `git` (requires git v1.7.10+):
 ```sh
 (
   cd "$NVM_DIR"
-  git fetch origin
+  git fetch --tags origin
   git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --tags --max-count=1)`
 ) && \. "$NVM_DIR/nvm.sh"
 ```


### PR DESCRIPTION
facilitates older `git` fetching tags so that it can actually upgrade properly

fixes #1772 ... again. 🤷‍♂️ 