### PR TITLE
allow user to explicitly opt out of nvm adding the source string

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -212,6 +212,11 @@ nvm_try_profile() {
 # Otherwise, an empty string is returned
 #
 nvm_detect_profile() {
+  if [ "${PROFILE-}" = '/dev/null' ]; then
+    # the user has specifically requested NOT to have nvm touch their profile
+    return
+  fi
+
   if [ -n "${PROFILE}" ] && [ -f "${PROFILE}" ]; then
     echo "${PROFILE}"
     return

--- a/test/install_script/nvm_detect_profile
+++ b/test/install_script/nvm_detect_profile
@@ -28,6 +28,12 @@ setup
 # Confirm profile detection via $SHELL works and that $PROFILE overrides profile detection
 #
 
+# setting $PROFILE to /dev/null should return no detected profile
+NVM_DETECT_PROFILE="$(PROFILE='/dev/null'; nvm_detect_profile)"
+if [ -n "$NVM_DETECT_PROFILE" ]; then
+  die "nvm_detect_profile still detected a profile even though PROFILE=/dev/null"
+fi
+
 # .bashrc should be detected for bash
 NVM_DETECT_PROFILE="$(BASH_VERSION="1"; unset PROFILE; nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.bashrc" ]; then


### PR DESCRIPTION
this is done by checking if the user supplies `PROFILE=/dev/null` when
running `install.sh`, the `nvm_detect_profile` function will not output
any strings, causing `nvm_do_install` to skip adding `SOURCE_STR`.

tests are included.