### PR TITLE
Improve nvm_is_version_installed to check for a node executable instead of root dir

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -130,7 +130,7 @@ nvm_has_system_iojs() {
 }
 
 nvm_is_version_installed() {
-  [ -n "${1-}" ] && [ -d "$(nvm_version_path "${1-}" 2> /dev/null)" ]
+  [ -n "${1-}" ] && [ -x "$(nvm_version_path "$1" 2> /dev/null)"/bin/node ]
 }
 
 nvm_print_npm_version() {

--- a/test/fast/Aliases/setup
+++ b/test/fast/Aliases/setup
@@ -1,11 +1,14 @@
 #!/bin/sh
 
+\. ../../../nvm.sh
+\. ../../common.sh
+
 for i in $(seq 1 10)
   do
   echo 0.0.$i > ../../../alias/test-stable-$i
-  mkdir -p ../../../v0.0.$i
+  make_fake_node v0.0.$i
   echo 0.1.$i > ../../../alias/test-unstable-$i
-  mkdir -p ../../../v0.1.$i
+  make_fake_node v0.1.$i
   echo 0.2.$i > ../../../alias/test-iojs-$i
-  mkdir -p ../../../versions/io.js/v0.2.$i
+  make_fake_iojs v0.2.$i
 done

--- a/test/fast/Running "nvm deactivate" should unset the nvm environment variables.
+++ b/test/fast/Running "nvm deactivate" should unset the nvm environment variables.
@@ -2,13 +2,14 @@
 
 set -ex
 
-mkdir -p ../../v0.2.3
-
 die () { echo "$@" ; exit 1; }
 
-[ `expr $PATH : ".*v0.2.3/.*/bin.*"` = 0 ] || echo "WARNING: Unexpectedly found v0.2.3 already active" >&2
-
 \. ../../nvm.sh
+\. ../common.sh
+
+make_fake_node v0.2.3
+
+[ `expr $PATH : ".*v0.2.3/.*/bin.*"` = 0 ] || echo "WARNING: Unexpectedly found v0.2.3 already active" >&2
 
 nvm use --delete-prefix v0.2.3 || die "Failed to activate v0.2.3"
 [ `expr "$PATH" : ".*v0.2.3/.*/bin.*"` != 0 ] || die "PATH not set up properly"

--- a/test/fast/Running "nvm uninstall" should remove the appropriate directory.
+++ b/test/fast/Running "nvm uninstall" should remove the appropriate directory.
@@ -2,11 +2,11 @@
 
 set -ex
 
-cd ../..
-mkdir v0.0.1
-mkdir src/node-v0.0.1
+\. ../../nvm.sh
+\. ../common.sh
 
-. ./nvm.sh
+make_fake_node v0.0.1
+
 nvm uninstall v0.0.1
 
-[ ! -d 'v0.0.1' ] && [ ! -d 'src/node-v0.0.1/files' ]
+[ ! -d 'v0.0.1' ]

--- a/test/fast/Running "nvm uninstall" with incorrect file permissions fails nicely
+++ b/test/fast/Running "nvm uninstall" with incorrect file permissions fails nicely
@@ -2,13 +2,11 @@
 
 set -ex
 
-cd ../..
-mkdir v0.0.1
-mkdir src/node-v0.0.1
+\. ../../nvm.sh
+\. ../common.sh
 
-sudo touch v0.0.1/sudo
-
-. ./nvm.sh
+make_fake_node v0.0.1
+sudo touch ""$(nvm_version_path v0.0.1)"/sudo"
 
 RETURN_MESSAGE="$(nvm uninstall v0.0.1 2>&1 || echo)"
 CHECK_FOR="Cannot uninstall, incorrect permissions on installation folder"

--- a/test/installation_node/install hook
+++ b/test/installation_node/install hook
@@ -19,6 +19,12 @@ fail() {
 
 ! nvm_is_version_installed "${VERSION}" || nvm uninstall "${VERSION}" || die 'uninstall failed'
 
+# an existing but empty VERSION_PATH directory should not be enough to satisfy nvm_is_version_installed
+rm -rf "${VERSION_PATH}"
+mkdir -p "${VERSION_PATH}"
+nvm_is_version_installed "${VERSION}" && die 'nvm_is_version_installed check not strict enough'
+rmdir "${VERSION_PATH}"
+
 OUTPUT="$(NVM_INSTALL_THIRD_PARTY_HOOK=succeed nvm install "${VERSION}")"
 USE_OUTPUT="$(nvm use "${VERSION}")"
 EXPECTED_OUTPUT="${VERSION} node std binary ${VERSION_PATH}


### PR DESCRIPTION
For some context, this was causing issues described in https://github.com/getsentry/sentry/pull/8623.

`nvm_is_version_installed` should not be checking for the presence of an installed node version by simply checking the presence of a directory in `versions/node`. It just isn't a strict enough check. One step would be to check for the presence of an executable `bin/node`, which is what this PR implements.

Even more strict would be to actually try and invoke `bin/node` itself afterwards, and comparing `[ "$(node -v)" = "v${1}" ]`. Please let me know if that sounds good, or if you have any questions.