### PR TITLE
Add support for ZSH_DISABLE_COMPFIX flag.

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -85,7 +85,11 @@ __nvm() {
 # ZSH, load and run bashcompinit before calling the complete function.
 if [[ -n ${ZSH_VERSION-} ]]; then
   autoload -U +X bashcompinit && bashcompinit
-  autoload -U +X compinit && compinit
+  autoload -U +X compinit && if [[ ${ZSH_DISABLE_COMPFIX-} = true ]]; then
+    compinit -u
+  else
+    compinit
+  fi
 fi
 
 complete -o default -F __nvm nvm


### PR DESCRIPTION
When using Oh My Zsh the ZSH_DISABLE_COMPFIX flag allows the zsh completion system to use files in directories it deems to be insecure.

In the case of the ZSH_DISABLE_COMPFIX flag not being true I added the -i flag to compinit. This flag will cause the zsh completion system to ignore files in directories it deems to be insecure. If this flag is not used the user will be prompted to either ignore insecure directories or abort compinit. Ignoring the insecure directories manually is the same as using the -i flag and aborting will cause autocompletion in zsh to fail. I believe -i would be the sane default here and this would be shared with Oh My Zsh.

Here is the relevant documentation on compinit: http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Use-of-compinit

And here is an example on how Oh My Zsh handles this problem: https://github.com/robbyrussell/oh-my-zsh/blob/e96a7b728a9c15f5615f4e41a79a5f0fe2b97712/oh-my-zsh.sh#L70