### PR TITLE
Logic for when $METHOD is something unexpected

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -329,6 +329,9 @@ nvm_do_install() {
       exit 1
     fi
     install_nvm_as_script
+  else
+    echo >&2 "The environment variable \$METHOD is set to \"${METHOD}\", which is not recognized as a valid installation method."
+    exit 1
   fi
 
   echo


### PR DESCRIPTION
Print an error and exit the script if $METHOD is set to something unexpected.

In my own personal case, Salt was setting $METHOD to "loopback", and I did not realize it. With this patch, the script output will make it clear what's going on, and it will not pretend to complete successfully.

I did a small amount of testing of my own, but I don't have the tools or experience to complete all the testing asked for in CONTRIBUTING.md. Can someone else help with that?