### PR TITLE
[Docs] fixing cdnvm on .bashrc (auto nvm use)

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ find-up () {
 }
 
 cdnvm(){
-    cd $@;
+    cd "$@";
     nvm_path=$(find-up .nvmrc | tr -d '[:space:]')
 
     # If there are no .nvmrc file, use the default nvm version


### PR DESCRIPTION
Automatically call `nvm use` using `.bashrc` file is broken for directories with to-be-escaped chars.
$ cd the\ folder/
bash : cd : too many arguments

Quoting $@ will fix this issue.
