### PR TITLE
[Fix] Make installation less restrictive when NVM_DIR is set

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,13 +6,19 @@ nvm_has() {
   type "$1" > /dev/null 2>&1
 }
 
-nvm_install_dir() {
-  if [ -n "$NVM_DIR" ]; then
-    printf %s "${NVM_DIR}"
-  elif [ -n "$XDG_CONFIG_HOME" ]; then
+nvm_default_install_dir() {
+  if [ -n "$XDG_CONFIG_HOME" ]; then
     printf %s "${XDG_CONFIG_HOME/nvm}"
   else
     printf %s "$HOME/.nvm"
+  fi
+}
+
+nvm_install_dir() {
+  if [ -n "$NVM_DIR" ]; then
+    printf %s "${NVM_DIR}"
+  else
+    nvm_default_install_dir
   fi
 }
 
@@ -304,13 +310,13 @@ nvm_check_global_modules() {
 
 nvm_do_install() {
   if [ -n "${NVM_DIR-}" ] && ! [ -d "${NVM_DIR}" ]; then
-    if [ "${NVM_DIR}" == "$HOME/.nvm" ]; then
-      if [ -e "${NVM_DIR}" ]; then
-        echo >&2 "File \"${NVM_DIR}\" has the same name as installation directory."
-        exit 1
-      else
-        mkdir "${NVM_DIR}"
-      fi
+    if [ -e "${NVM_DIR}" ]; then
+      echo >&2 "File \"${NVM_DIR}\" has the same name as installation directory."
+      exit 1
+    fi
+
+    if [ "${NVM_DIR}" = "$(nvm_default_install_dir)" ]; then
+      mkdir "${NVM_DIR}"
     else
       echo >&2 "You have \$NVM_DIR set to \"${NVM_DIR}\", but that directory does not exist. Check your profile files and environment."
       exit 1
@@ -415,7 +421,7 @@ nvm_reset() {
   unset -f nvm_has nvm_install_dir nvm_latest_version nvm_profile_is_bash_or_zsh \
     nvm_source nvm_node_version nvm_download install_nvm_from_git nvm_install_node \
     install_nvm_as_script nvm_try_profile nvm_detect_profile nvm_check_global_modules \
-    nvm_do_install nvm_reset
+    nvm_do_install nvm_reset nvm_default_install_dir
 }
 
 [ "_$NVM_ENV" = "_testing" ] || nvm_do_install

--- a/install.sh
+++ b/install.sh
@@ -304,8 +304,17 @@ nvm_check_global_modules() {
 
 nvm_do_install() {
   if [ -n "${NVM_DIR-}" ] && ! [ -d "${NVM_DIR}" ]; then
-    echo >&2 "You have \$NVM_DIR set to \"${NVM_DIR}\", but that directory does not exist. Check your profile files and environment."
-    exit 1
+    if [ "${NVM_DIR}" == "$HOME/.nvm" ]; then
+      if [ -e "${NVM_DIR}" ]; then
+        echo >&2 "File \"${NVM_DIR}\" has the same name as installation directory."
+        exit 1
+      else
+        mkdir "${NVM_DIR}"
+      fi
+    else
+      echo >&2 "You have \$NVM_DIR set to \"${NVM_DIR}\", but that directory does not exist. Check your profile files and environment."
+      exit 1
+    fi
   fi
   if [ -z "${METHOD}" ]; then
     # Autodetect install method


### PR DESCRIPTION
This PR fixes #1962. 

It handles the following cases while installing nvm:
- ~If `NVM_DIR` is defined and set to anything other than the default value, exit installation~
- If `NVM_DIR` is defined and set to a file location not a directory, exit installation
- Otherwise if `NVM_DIR` doesn't already exist, create the folder
- Otherwise, continue