### PR TITLE
Update `cdnvm` script to take into account alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,17 +457,18 @@ cdnvm(){
         declare nvm_version
         nvm_version=$(<"$nvm_path"/.nvmrc)
 
-        # Add the `v` suffix if it does not exists in the .nvmrc file
-        if [[ $nvm_version != v* ]]; then
-            nvm_version="v""$nvm_version"
-        fi
+        declare locally_resolved_nvm_version
+        # `nvm ls` will check all locally-available versions
+        # If there are multiple matching versions, take the latest one
+        # Remove the `->` and `*` characters and spaces
+        # `locally_resolved_nvm_version` will be `N/A` if no local versions are found
+        locally_resolved_nvm_version=$(nvm ls --no-colors $(<"./.nvmrc") | tail -1 | tr -d '\->*' | tr -d '[:space:]')
 
         # If it is not already installed, install it
-        if [[ $(nvm ls "$nvm_version" | tr -d '[:space:]') == "N/A" ]]; then
+        # `nvm install` will implicitly use the newly-installed version
+        if [[ "$locally_resolved_nvm_version" == "N/A" ]]; then
             nvm install "$nvm_version";
-        fi
-
-        if [[ $(nvm current) != "$nvm_version" ]]; then
+        elif [[ $(nvm current) != "$locally_resolved_nvm_version" ]]; then
             nvm use "$nvm_version";
         fi
     fi


### PR DESCRIPTION
Only works for common aliases like `default`, `system`, `node`, `lts/*`, `iojs` etc.