### PR TITLE
Fix: failed to connect to github when run 'install.sh'

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,14 +51,14 @@ nvm_source() {
   local NVM_SOURCE_URL
   NVM_SOURCE_URL="$NVM_SOURCE"
   if [ "_$NVM_METHOD" = "_script-nvm-exec" ]; then
-    NVM_SOURCE_URL="https://raw.githubusercontent.com/creationix/nvm/$(nvm_latest_version)/nvm-exec"
+    NVM_SOURCE_URL="git://raw.githubusercontent.com/creationix/nvm/$(nvm_latest_version)/nvm-exec"
   elif [ "_$NVM_METHOD" = "_script-nvm-bash-completion" ]; then
-    NVM_SOURCE_URL="https://raw.githubusercontent.com/creationix/nvm/$(nvm_latest_version)/bash_completion"
+    NVM_SOURCE_URL="git://raw.githubusercontent.com/creationix/nvm/$(nvm_latest_version)/bash_completion"
   elif [ -z "$NVM_SOURCE_URL" ]; then
     if [ "_$NVM_METHOD" = "_script" ]; then
-      NVM_SOURCE_URL="https://raw.githubusercontent.com/creationix/nvm/$(nvm_latest_version)/nvm.sh"
+      NVM_SOURCE_URL="git://raw.githubusercontent.com/creationix/nvm/$(nvm_latest_version)/nvm.sh"
     elif [ "_$NVM_METHOD" = "_git" ] || [ -z "$NVM_METHOD" ]; then
-      NVM_SOURCE_URL="https://github.com/creationix/nvm.git"
+      NVM_SOURCE_URL="git://github.com/creationix/nvm.git"
     else
       echo >&2 "Unexpected value \"$NVM_METHOD\" for \$NVM_METHOD"
       return 1


### PR DESCRIPTION
Replace protocol https with git to let install.sh work in an environment where the HTTPS/SSL connection cannot be available somehow. 

==== how to retrigger
```
bash-3.2# GIT_CURL_VERBOSE=1 GIT_TRACE=1 git -c
advice.detachedHead=false clone https://github.com/creationix/nvm.git -b
v0.34.0 --depth=1
21:49:01.676517 git.c:419               trace: built-in: git clone
https://github.com/creationix/nvm.git -b v0.34.0 --depth=1
Cloning into 'nvm'...
21:49:01.678041 run-command.c:643       trace: run_command:
git-remote-https origin https://github.com/creationix/nvm.git
warning: Protocol restrictions not supported with cURL < 7.19.4
* Couldn't find host github.com in the .netrc file; using defaults
*   Trying 192.30.255.113...
* TCP_NODELAY set
* Connected to github.com (192.30.255.113) port 443 (#0)
* Cipher selection:
* ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: none
  CApath: /etc/ssl/certs/
* OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443
* Closing connection 0
fatal: unable to access 'https://github.com/creationix/nvm.git/':
OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443

```
==== environment 
```
bash-3.2# git --version
git version 2.21.0
bash-3.2# curl --version
curl 7.64.1 (x86_64-pc-linux-gnu) libcurl/7.64.1 OpenSSL/0.9.7m
zlib/1.2.3
Release-Date: 2019-03-27
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps
pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: AsynchDNS HTTPS-proxy IPv6 Largefile libz NTLM NTLM_WB SSL
UnixSockets

```
==== Refer
https://github.com/angular/angular-phonecat/issues/212